### PR TITLE
fix: naming inconsistencies

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -38,7 +38,7 @@ module Val = struct
   type t =
     | Unit  (** [unit] literal *)
     | Pair of t * t  (** [(lit1, lit2)] -- a pair of literals is a literal *)
-    | Clos of Id.R.t * Expr.t * t Env.l  (** Deeply embedded closures *)
+    | Clos of Id.R.t * Expr.t * t Env.r  (** Deeply embedded closures *)
     | Box of Expr.t
         (** [box] literal, basically it's an unevaluated expression *)
   [@@deriving sexp]

--- a/src/Env.ml
+++ b/src/Env.ml
@@ -1,14 +1,14 @@
 open Base
 open Result.Let_syntax
 
-type 'a g = (Id.M.t * 'a) list
+type 'a m = (Id.M.t * 'a) list
 (** Modal environment *)
 
-let emp_g = []
+let emp_m = []
 
-let extend_g delta id v = (id, v) :: delta
+let extend_m delta id v = (id, v) :: delta
 
-let lookup_g delta id =
+let lookup_m delta id =
   let typ_o = List.Assoc.find delta id ~equal:[%equal: Id.M.t] in
   match typ_o with
   | Some t -> return t
@@ -17,14 +17,14 @@ let lookup_g delta id =
       Result.fail
         [%string "Variable $(var_name) is not found in the modal context!"]
 
-type 'a l = (Id.R.t * 'a) list [@@deriving sexp]
-(** Local environment *)
+type 'a r = (Id.R.t * 'a) list [@@deriving sexp]
+(** Regular environment *)
 
-let emp_l = []
+let emp_r = []
 
-let extend_l gamma id v = (id, v) :: gamma
+let extend_r gamma id v = (id, v) :: gamma
 
-let lookup_l gamma id =
+let lookup_r gamma id =
   let typ_o = List.Assoc.find gamma id ~equal:[%equal: Id.R.t] in
   match typ_o with
   | Some t -> return t

--- a/src/Env.mli
+++ b/src/Env.mli
@@ -2,32 +2,32 @@ open Base
 
 (** Environment interface *)
 
-type 'a g
+type 'a m
 (** Modal environment (\Delta, or environment for validities).
     Parameterized by the type of values it stores *)
 
-type 'a l [@@deriving sexp]
+type 'a r [@@deriving sexp]
 (** Regular environment (\Gamma).
     Parameterized by the type of values it stores *)
 
 (** Constructors *)
 
-val emp_g : 'a g
+val emp_m : 'a m
 (** Empty modal environment *)
 
-val extend_g : 'a g -> Id.M.t -> 'a -> 'a g
+val extend_m : 'a m -> Id.M.t -> 'a -> 'a m
 (** Extend modal environment with an id and the corresponding value *)
 
-val emp_l : 'a l
+val emp_r : 'a r
 (** Empty regular environment *)
 
-val extend_l : 'a l -> Id.R.t -> 'a -> 'a l
+val extend_r : 'a r -> Id.R.t -> 'a -> 'a r
 (** Extend regular environment with an id and the corresponding value *)
 
 (** Destructors *)
 
-val lookup_g : 'a g -> Id.M.t -> ('a, string) Result.t
+val lookup_m : 'a m -> Id.M.t -> ('a, string) Result.t
 (** Find the value corresponding to a modal identifier *)
 
-val lookup_l : 'a l -> Id.R.t -> ('a, string) Result.t
+val lookup_r : 'a r -> Id.R.t -> ('a, string) Result.t
 (** Find the value corresponding to a regular identifier *)

--- a/src/Evaluator.ml
+++ b/src/Evaluator.ml
@@ -4,22 +4,22 @@ open Ast
 
 type error = string
 
-let rec free_vars_g term =
+let rec free_vars_m term =
   let open Expr in
   match term with
   | Unit -> Set.empty (module Id.M)
-  | Pair (e1, e2) -> Set.union (free_vars_g e1) (free_vars_g e2)
-  | Fst pe | Snd pe -> free_vars_g pe
+  | Pair (e1, e2) -> Set.union (free_vars_m e1) (free_vars_m e2)
+  | Fst pe | Snd pe -> free_vars_m pe
   | VarL _i -> Set.empty (module Id.M)
   | VarG i -> Set.singleton (module Id.M) i
-  | Fun (_i, _t_of_id, body) -> free_vars_g body
-  | App (fe, arge) -> Set.union (free_vars_g fe) (free_vars_g arge)
-  | Box e -> free_vars_g e
+  | Fun (_i, _t_of_id, body) -> free_vars_m body
+  | App (fe, arge) -> Set.union (free_vars_m fe) (free_vars_m arge)
+  | Box e -> free_vars_m e
   | Letbox (i, boxed_e, body) ->
-      Set.union (free_vars_g boxed_e)
-        (Set.diff (free_vars_g body) (Set.singleton (module Id.M) i))
+      Set.union (free_vars_m boxed_e)
+        (Set.diff (free_vars_m body) (Set.singleton (module Id.M) i))
 
-let refresh_g idg fvs =
+let refresh_m idg fvs =
   let rec loop (idg : Id.M.t) =
     if Set.mem fvs idg then loop (Id.M.mk (Id.M.to_string idg ^ "'")) else idg
     (* it's fresh enough already :) *)
@@ -42,7 +42,7 @@ let rec subst_m term idg body =
   | Letbox (i, boxed_e, body) -> (
       if [%equal: Id.M.t] idg i then Letbox (i, subst_m term idg boxed_e, body)
       else
-        match refresh_g i (free_vars_g term) with
+        match refresh_m i (free_vars_m term) with
         | Some new_i ->
             let body_with_renamed_bound_var = subst_m (VarG new_i) i body in
             Letbox
@@ -70,7 +70,7 @@ let rec eval_open gamma expr =
       match pv with
       | Val.Pair (_v1, v2) -> return v2
       | _ -> Result.fail "snd is stuck" )
-  | VarL idl -> Env.lookup_l gamma idl
+  | VarL idl -> Env.lookup_r gamma idl
   | VarG _idg ->
       Result.fail "Modal variable access is not possible in a well-typed term"
   | Fun (idl, _t_of_id, body) -> return @@ Val.Clos (idl, body, gamma)
@@ -79,7 +79,7 @@ let rec eval_open gamma expr =
       let%bind argv = eval_open gamma arge in
       match fv with
       | Val.Clos (idl, body, c_gamma) ->
-          eval_open (Env.extend_l c_gamma idl argv) body
+          eval_open (Env.extend_r c_gamma idl argv) body
       | _ -> Result.fail "Trying to apply an argument to a non-function" )
   | Box e -> return @@ Val.Box e
   | Letbox (idg, boxed_e, body) -> (
@@ -88,4 +88,4 @@ let rec eval_open gamma expr =
       | Val.Box e -> eval_open gamma (subst_m e idg body)
       | _ -> Result.fail "Trying to unbox a non-box expression" )
 
-let eval expr = eval_open Env.emp_l expr
+let eval expr = eval_open Env.emp_r expr

--- a/src/Evaluator.mli
+++ b/src/Evaluator.mli
@@ -4,10 +4,10 @@ open Ast
 type error = string
 (** Type of errors *)
 
-val free_vars_g : Expr.t -> (Id.M.t, Id.M.comparator_witness) Set.t
+val free_vars_m : Expr.t -> (Id.M.t, Id.M.comparator_witness) Set.t
 (** Compute the set of free modal variables in a term *)
 
-val refresh_g :
+val refresh_m :
   Id.M.t -> (Id.M.t, Id.M.comparator_witness) Set.t -> Id.M.t option
 (** Given a modal identifier and a set of free modal variables,
     come up with a new name that won't capture any of the free modal variables.
@@ -17,7 +17,7 @@ val subst_m : Expr.t -> Id.M.t -> Expr.t -> Expr.t
 (** Capture-avoiding modal substitution: "[term/idg]body",
     i.e. substitute [term] for free variable [idg] in [body] *)
 
-val eval_open : Val.t Env.l -> Expr.t -> (Val.t, error) Result.t
+val eval_open : Val.t Env.r -> Expr.t -> (Val.t, error) Result.t
 (** Evaluate a possibly open term in a regular context *)
 
 val eval : Expr.t -> (Val.t, error) Result.t

--- a/src/Parser.mly
+++ b/src/Parser.mly
@@ -86,12 +86,12 @@ expr:
     { Snd (e) }
 
     (* anonymous function (lambda) *)
-  | FUN; idl = IDR; COLON; t = typ; DARROW; e = expr
-    { Fun (Id.R.mk idl, t, e) }
+  | FUN; idr = IDR; COLON; t = typ; DARROW; e = expr
+    { Fun (Id.R.mk idr, t, e) }
 
     (* allow parenthesizing of the bound variable for lambdas *)
-  | FUN; LPAREN; idl = IDR; COLON; t = typ; RPAREN; DARROW; e = expr
-    { Fun (Id.R.mk idl, t, e) }
+  | FUN; LPAREN; idr = IDR; COLON; t = typ; RPAREN; DARROW; e = expr
+    { Fun (Id.R.mk idr, t, e) }
 
     (* function application (f x) *)
   | fe = parceled_expr; arge = parceled_expr

--- a/src/PrettyPrinter.ml
+++ b/src/PrettyPrinter.ml
@@ -48,7 +48,7 @@ module Doc : DOC = struct
 
   (** Pretty-print expressions with free vars substituited with
     their corresponding values from a regular environment *)
-  let rec of_expr_with_free_vars_l bound_vars lenv expr =
+  let rec of_expr_with_free_vars_r bound_vars lenv expr =
     let open Expr in
     let rec walk bvs = function
       | Unit -> unit_term
@@ -61,11 +61,11 @@ module Doc : DOC = struct
             Set.mem bvs idl
           then !^(Id.R.to_string idl)
           else
-            match Env.lookup_l lenv idl with
+            match Env.lookup_r lenv idl with
             | Ok literal -> parens (of_lit literal)
             | Error _msg ->
                 failwith
-                  "The precondition for calling Doc.of_expr_with_free_vars_l \
+                  "The precondition for calling Doc.of_expr_with_free_vars_r \
                    function is violated" )
       | VarG idg -> !^(Id.M.to_string idg)
       | Fun (idl, t_of_id, body) ->
@@ -86,7 +86,7 @@ module Doc : DOC = struct
     walk bound_vars expr
 
   (* This prints an expression as-is, i.e. no substitutions for free vars *)
-  and of_expr e = of_expr_with_free_vars_l (Set.empty (module Id.R)) Env.emp_l e
+  and of_expr e = of_expr_with_free_vars_r (Set.empty (module Id.R)) Env.emp_r e
 
   and of_lit = function
     | Val.Unit -> unit_term
@@ -99,6 +99,6 @@ module Doc : DOC = struct
         (* when print out closures, substitute the free vars in its body with
            the corresponding literals from the closures' regular environment *)
         let bound_vars = Set.singleton (module Id.R) idl in
-        of_expr_with_free_vars_l bound_vars lenv body
+        of_expr_with_free_vars_r bound_vars lenv body
     | Val.Box e -> box_kwd ^^^ of_expr e
 end

--- a/src/Typechecker.ml
+++ b/src/Typechecker.ml
@@ -35,12 +35,12 @@ let rec check_open delta gamma expr typ =
             ~error:"snd error: inferred type is different from the input one"
       | _ -> Result.fail "snd is applied to a non-product type" )
   | VarL idl ->
-      let%bind t = Env.lookup_l gamma idl in
+      let%bind t = Env.lookup_r gamma idl in
       Result.ok_if_true
         ([%equal: Type.t] typ t)
         ~error:"Unexpected regular variable type"
   | VarG idg ->
-      let%bind t = Env.lookup_g delta idg in
+      let%bind t = Env.lookup_m delta idg in
       Result.ok_if_true
         ([%equal: Type.t] typ t)
         ~error:"Unexpected modal variable type"
@@ -48,7 +48,7 @@ let rec check_open delta gamma expr typ =
       match typ with
       | Type.Arr (dom, cod) ->
           if [%equal: Type.t] dom t_of_id then
-            check_open delta (Env.extend_l gamma idl dom) body cod
+            check_open delta (Env.extend_r gamma idl dom) body cod
           else
             Result.fail
               "Domain of arrow type is not the same as type of function \
@@ -65,12 +65,12 @@ let rec check_open delta gamma expr typ =
       | _ -> Result.fail "Inferred type is not an arrow type" )
   | Box e -> (
       match typ with
-      | Type.Box t -> check_open delta Env.emp_l e t
+      | Type.Box t -> check_open delta Env.emp_r e t
       | _ -> Result.fail "Error: unboxed type" )
   | Letbox (idg, boxed_e, body) -> (
       let%bind ty = infer_open delta gamma boxed_e in
       match ty with
-      | Type.Box t -> check_open (Env.extend_g delta idg t) gamma body typ
+      | Type.Box t -> check_open (Env.extend_m delta idg t) gamma body typ
       | _ -> Result.fail "Inferred type is not a box" )
 
 and infer_open delta gamma expr =
@@ -90,10 +90,10 @@ and infer_open delta gamma expr =
       match t with
       | Type.Prod (_t1, t2) -> return t2
       | _ -> Result.fail "snd is applied to a non-product type" )
-  | VarL idl -> Env.lookup_l gamma idl
-  | VarG idg -> Env.lookup_g delta idg
+  | VarL idl -> Env.lookup_r gamma idl
+  | VarG idg -> Env.lookup_m delta idg
   | Fun (idl, dom, body) ->
-      let%map cod = infer_open delta (Env.extend_l gamma idl dom) body in
+      let%map cod = infer_open delta (Env.extend_r gamma idl dom) body in
       Type.Arr (dom, cod)
   | App (fe, arge) -> (
       let%bind t = infer_open delta gamma fe in
@@ -103,14 +103,14 @@ and infer_open delta gamma expr =
           return cod
       | _ -> Result.fail "Inferred type is not an arrow type" )
   | Box e ->
-      let%map t = infer_open delta Env.emp_l e in
+      let%map t = infer_open delta Env.emp_r e in
       Type.Box t
   | Letbox (idg, boxed_e, body) -> (
       let%bind ty = infer_open delta gamma boxed_e in
       match ty with
-      | Type.Box t -> infer_open (Env.extend_g delta idg t) gamma body
+      | Type.Box t -> infer_open (Env.extend_m delta idg t) gamma body
       | _ -> Result.fail "Inferred type is not a box" )
 
-let check expr typ = check_open Env.emp_g Env.emp_l expr typ
+let check expr typ = check_open Env.emp_m Env.emp_r expr typ
 
-let infer expr = infer_open Env.emp_g Env.emp_l expr
+let infer expr = infer_open Env.emp_m Env.emp_r expr

--- a/src/Typechecker.mli
+++ b/src/Typechecker.mli
@@ -4,7 +4,7 @@ open Ast
 type error = string
 
 val check_open :
-  Type.t Env.g -> Type.t Env.l -> Expr.t -> Type.t -> (unit, error) Result.t
+  Type.t Env.m -> Type.t Env.r -> Expr.t -> Type.t -> (unit, error) Result.t
 (** [check_open delta gamma term type] typechecks a possibly open term [term]
     in modal (valid) typing context [delta] and regular typing context [gamma].
  *)
@@ -13,7 +13,7 @@ val check : Expr.t -> Type.t -> (unit, error) Result.t
 (** Typecheck a closed term *)
 
 val infer_open :
-  Type.t Env.g -> Type.t Env.l -> Expr.t -> (Type.t, error) Result.t
+  Type.t Env.m -> Type.t Env.r -> Expr.t -> (Type.t, error) Result.t
 (** [infer_open delta gamma term] infers the type of a possibly open term [term]
     in modal (valid) typing context [delta] and regular typing context [gamma].
  *)


### PR DESCRIPTION
The remainings of prev. naming local/global are changed into regular/modal. Sorry for inconvenience, folks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anton-trunov/modal-type-theory/36)
<!-- Reviewable:end -->
