### PR TITLE
refactor: rename idg -> idm; idl -> idr; VarL -> VarR; VarG -> VarM

### DIFF
--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -23,8 +23,8 @@ module Expr = struct
     | Pair of t * t  (** pairs [(expr1, expr2)] *)
     | Fst of t  (** first projection of a pair *)
     | Snd of t  (** second projection of a pair *)
-    | VarL of Id.R.t  (** variables of the regular context *)
-    | VarG of Id.M.t
+    | VarR of Id.R.t  (** variables of the regular context *)
+    | VarM of Id.M.t
         (** variables of the modal context (or "valid variables"),
         these are syntactically distinct from the regular (ordinary) variables *)
     | Fun of Id.R.t * Type.t * t
@@ -44,19 +44,19 @@ module Expr = struct
 
   let snd pe = Location.locate @@ Snd pe
 
-  let varl idl = Location.locate @@ VarL idl
+  let varl idr = Location.locate @@ VarR idr
 
-  let varg idg = Location.locate @@ VarG idg
+  let varg idm = Location.locate @@ VarM idm
 
-  let func idl t_of_id body = Location.locate @@ Fun (idl, t_of_id, body)
+  let func idr t_of_id body = Location.locate @@ Fun (idr, t_of_id, body)
 
   let app fe arge = Location.locate @@ App (fe, arge)
 
   let box e = Location.locate @@ Box e
 
-  let letc idl bound_e body = Location.locate @@ Let (idl, bound_e, body)
+  let letc idr bound_e body = Location.locate @@ Let (idr, bound_e, body)
 
-  let letbox idg boxed_e body = Location.locate @@ Letbox (idg, boxed_e, body)
+  let letbox idm boxed_e body = Location.locate @@ Letbox (idm, boxed_e, body)
 end
 
 (** Values *)

--- a/src/Evaluator.ml
+++ b/src/Evaluator.ml
@@ -10,8 +10,8 @@ let rec free_vars_m Location.{ data = term; _ } =
   | Unit -> Set.empty (module Id.M)
   | Pair (e1, e2) -> Set.union (free_vars_m e1) (free_vars_m e2)
   | Fst pe | Snd pe -> free_vars_m pe
-  | VarL _i -> Set.empty (module Id.M)
-  | VarG i -> Set.singleton (module Id.M) i
+  | VarR _i -> Set.empty (module Id.M)
+  | VarM i -> Set.singleton (module Id.M) i
   | Fun (_i, _t_of_id, body) -> free_vars_m body
   | App (fe, arge) -> Set.union (free_vars_m fe) (free_vars_m arge)
   | Box e -> free_vars_m e
@@ -21,48 +21,49 @@ let rec free_vars_m Location.{ data = term; _ } =
       Set.union (free_vars_m boxed_e)
         (Set.diff (free_vars_m body) (Set.singleton (module Id.M) i))
 
-let refresh_m idg fvs =
-  let rec loop (idg : Id.M.t) =
-    if Set.mem fvs idg then loop (Id.M.mk (Id.M.to_string idg ^ "'")) else idg
+let refresh_m idm fvs =
+  let rec loop (idm : Id.M.t) =
+    if Set.mem fvs idm then loop (Id.M.mk (Id.M.to_string idm ^ "'")) else idm
     (* it's fresh enough already :) *)
   in
-  if Set.mem fvs idg then Some (loop idg) else None
+  if Set.mem fvs idm then Some (loop idm) else None
 
 (* modal (modal) substitution *)
-let rec subst_m term idg Location.{ data = body; _ } =
+let rec subst_m term idm Location.{ data = body; _ } =
   let open Expr in
   match body with
   | Unit -> Location.locate body
   | Pair (e1, e2) ->
-      Location.locate (Pair (subst_m term idg e1, subst_m term idg e2))
-  | Fst pe -> Location.locate (Fst (subst_m term idg pe))
-  | Snd pe -> Location.locate (Snd (subst_m term idg pe))
-  | VarL _i -> Location.locate body
-  | VarG i -> if [%equal: Id.M.t] idg i then term else Location.locate body
-  | Fun (idl, t_of_id, body) ->
-      Location.locate (Fun (idl, t_of_id, subst_m term idg body))
+      Location.locate (Pair (subst_m term idm e1, subst_m term idm e2))
+  | Fst pe -> Location.locate (Fst (subst_m term idm pe))
+  | Snd pe -> Location.locate (Snd (subst_m term idm pe))
+  | VarR _i -> Location.locate body
+  | VarM i -> if [%equal: Id.M.t] idm i then term else Location.locate body
+  | Fun (idr, t_of_id, body) ->
+      Location.locate (Fun (idr, t_of_id, subst_m term idm body))
   | App (fe, arge) ->
-      Location.locate (App (subst_m term idg fe, subst_m term idg arge))
-  | Box e -> Location.locate (Box (subst_m term idg e))
-  | Let (i, bound_e, body) ->
-      Location.locate (Let (i, subst_m term idg bound_e, subst_m term idg body))
+      Location.locate (App (subst_m term idm fe, subst_m term idm arge))
+  | Box e -> Location.locate (Box (subst_m term idm e))
+  | Let (idr, bound_e, body) ->
+      Location.locate
+        (Let (idr, subst_m term idm bound_e, subst_m term idm body))
   | Letbox (i, boxed_e, body) ->
       Location.locate
-        ( if [%equal: Id.M.t] idg i then
-          Letbox (i, subst_m term idg boxed_e, body)
+        ( if [%equal: Id.M.t] idm i then
+          Letbox (i, subst_m term idm boxed_e, body)
         else
           match refresh_m i (free_vars_m term) with
           | Some new_i ->
               let body_with_renamed_bound_var =
-                subst_m (Location.locate (VarG new_i)) i body
+                subst_m (Location.locate (VarM new_i)) i body
               in
               Letbox
                 ( new_i,
-                  subst_m term idg boxed_e,
-                  subst_m term idg body_with_renamed_bound_var )
+                  subst_m term idm boxed_e,
+                  subst_m term idm body_with_renamed_bound_var )
           | None ->
               (* no need to rename the bound var *)
-              Letbox (i, subst_m term idg boxed_e, subst_m term idg body) )
+              Letbox (i, subst_m term idm boxed_e, subst_m term idm body) )
 
 let rec eval_open gamma Location.{ data = expr; _ } =
   let open Expr in
@@ -81,25 +82,25 @@ let rec eval_open gamma Location.{ data = expr; _ } =
       match pv with
       | Val.Pair (_v1, v2) -> return v2
       | _ -> Result.fail "snd is stuck" )
-  | VarL idl -> Env.R.lookup gamma idl
-  | VarG _idg ->
+  | VarR idr -> Env.R.lookup gamma idr
+  | VarM _idm ->
       Result.fail "Modal variable access is not possible in a well-typed term"
-  | Fun (idl, _t_of_id, body) -> return @@ Val.Clos (idl, body, gamma)
+  | Fun (idr, _t_of_id, body) -> return @@ Val.Clos (idr, body, gamma)
   | App (fe, arge) -> (
       let%bind fv = eval_open gamma fe in
       let%bind argv = eval_open gamma arge in
       match fv with
-      | Val.Clos (idl, body, c_gamma) ->
-          eval_open (Env.R.extend c_gamma idl argv) body
+      | Val.Clos (idr, body, c_gamma) ->
+          eval_open (Env.R.extend c_gamma idr argv) body
       | _ -> Result.fail "Trying to apply an argument to a non-function" )
   | Box e -> return @@ Val.Box e
   | Let (idr, bound_e, body) ->
       let%bind bound_v = eval_open gamma bound_e in
       eval_open (Env.R.extend gamma idr bound_v) body
-  | Letbox (idg, boxed_e, body) -> (
+  | Letbox (idm, boxed_e, body) -> (
       let%bind boxed_v = eval_open gamma boxed_e in
       match boxed_v with
-      | Val.Box e -> eval_open gamma (subst_m e idg body)
+      | Val.Box e -> eval_open gamma (subst_m e idm body)
       | _ -> Result.fail "Trying to unbox a non-box expression" )
 
 let eval expr = eval_open Env.R.emp expr

--- a/src/Evaluator.mli
+++ b/src/Evaluator.mli
@@ -14,8 +14,8 @@ val refresh_m :
     Returns [None] if no refreshment is needed and [Some new_name] otherwise *)
 
 val subst_m : Expr.t -> Id.M.t -> Expr.t -> Expr.t
-(** Capture-avoiding modal substitution: "[term/idg]body",
-    i.e. substitute [term] for free variable [idg] in [body] *)
+(** Capture-avoiding modal substitution: "[term/idm]body",
+    i.e. substitute [term] for free variable [idm] in [body] *)
 
 val eval_open : Val.t Env.R.t -> Expr.t -> (Val.t, error) Result.t
 (** Evaluate a possibly open term in a regular context *)

--- a/src/Parser.mly
+++ b/src/Parser.mly
@@ -71,11 +71,11 @@ typ:
 ident:
     (* Regular variables *)
   | name = IDR
-    { Location.locate_start_end (VarL (Id.R.mk name)) $symbolstartpos $endpos }
+    { Location.locate_start_end (VarR (Id.R.mk name)) $symbolstartpos $endpos }
 
     (* Modal (i.e. valid) variables *)
   | name = IDM
-    { Location.locate_start_end (VarG (Id.M.mk name)) $symbolstartpos $endpos }
+    { Location.locate_start_end (VarM (Id.M.mk name)) $symbolstartpos $endpos }
 
 expr:
     (* First projection *)
@@ -106,9 +106,9 @@ expr:
   | LET; idr = IDR; EQ; e = expr; IN; body = expr
     { Location.locate_start_end (Let (Id.R.mk idr, e, body)) $symbolstartpos $endpos }
 
-    (* letbox idg = expr in expr *)
-  | LETBOX; idg = IDM; EQ; e = expr; IN; body = expr
-    { Location.locate_start_end (Letbox (Id.M.mk idg, e, body)) $symbolstartpos $endpos }
+    (* letbox idm = expr in expr *)
+  | LETBOX; idm = IDM; EQ; e = expr; IN; body = expr
+    { Location.locate_start_end (Letbox (Id.M.mk idm, e, body)) $symbolstartpos $endpos }
 
   | e = parceled_expr
     { e }

--- a/src/PrettyPrinter.ml
+++ b/src/PrettyPrinter.ml
@@ -64,25 +64,25 @@ module Doc : DOC = struct
       | Pair (e1, e2) -> angles (walk bvs 1 e1 ^^ comma ^/^ walk bvs 1 e2)
       | Fst pe -> group (parens (fst_kwd ^^ walk bvs 2 pe))
       | Snd pe -> group (parens (snd_kwd ^^ walk bvs 2 pe))
-      | VarL idl -> (
+      | VarR idr -> (
           if
             (* To print free regular variables we use a regular environment with literals *)
-            Set.mem bvs idl
-          then !^(Id.R.to_string idl)
+            Set.mem bvs idr
+          then !^(Id.R.to_string idr)
           else
-            match Env.R.lookup lenv idl with
+            match Env.R.lookup lenv idr with
             | Ok literal -> parens (of_lit literal)
             | Error _msg ->
                 failwith
                   "The precondition for calling Doc.of_expr_with_free_vars_r \
                    function is violated" )
-      | VarG idg -> !^(Id.M.to_string idg)
-      | Fun (idl, t_of_id, body) ->
+      | VarM idm -> !^(Id.M.to_string idm)
+      | Fun (idr, t_of_id, body) ->
           (parens_if (p > 1))
             ( fun_kwd
-            ^^ !^(Id.R.to_string idl)
+            ^^ !^(Id.R.to_string idr)
             ^^^ colon ^^^ of_type t_of_id ^^ dot ^^ space
-            ^^ walk (Set.add bvs idl) 1 body )
+            ^^ walk (Set.add bvs idr) 1 body )
       | App (fe, arge) ->
           group ((parens_if (p >= 2)) (walk bvs 2 fe ^/^ walk bvs 2 arge))
       | Box e -> group ((parens_if (p >= 2)) (box_kwd ^^ space ^^ walk bvs 2 e))
@@ -93,11 +93,11 @@ module Doc : DOC = struct
                ^^^ !^(Id.R.to_string idr)
                ^^^ equals ^^^ walk bvs 2 bound_e ^^^ in_kwd
                ^/^ walk (Set.add bvs idr) 1 body ))
-      | Letbox (idg, boxed_e, body) ->
+      | Letbox (idm, boxed_e, body) ->
           (parens_if (p > 1))
             (group
                ( letbox_kwd
-               ^^^ !^(Id.M.to_string idg)
+               ^^^ !^(Id.M.to_string idm)
                ^^^ equals ^^^ walk bvs 2 boxed_e ^^^ in_kwd ^/^ walk bvs 1 body
                ))
     in
@@ -109,14 +109,14 @@ module Doc : DOC = struct
   and of_lit = function
     | Val.Unit -> unit_term
     | Val.Pair (l1, l2) -> group (angles (of_lit l1 ^^ comma ^/^ of_lit l2))
-    | Val.Clos (idl, body, lenv) ->
+    | Val.Clos (idr, body, lenv) ->
         fun_kwd
-        ^^ !^(Id.R.to_string idl)
+        ^^ !^(Id.R.to_string idr)
         ^^ dot
         ^^^
         (* when print out closures, substitute the free vars in its body with
            the corresponding literals from the closures' regular environment *)
-        let bound_vars = Set.singleton (module Id.R) idl in
+        let bound_vars = Set.singleton (module Id.R) idr in
         of_expr_with_free_vars_r bound_vars lenv body
     | Val.Box e -> box_kwd ^^^ of_expr e
 end

--- a/test/pretty-printer/ppTest.ml
+++ b/test/pretty-printer/ppTest.ml
@@ -19,9 +19,9 @@ let generator =
                    return Expr.unit;
                    (* won't work until expressions with free variables can be pretty-printed *)
                    (* map
-                      (fun s -> Expr.VarL (Mtt.Id.R.mk s))
+                      (fun s -> Expr.VarR (Mtt.Id.R.mk s))
                       (string_size ~gen:(char_range 'a' 'z') (return 1)); *)
-                   map (fun idg -> Expr.varg (modal_id idg)) lowercase_id;
+                   map (fun idm -> Expr.varg (modal_id idm)) lowercase_id;
                  ]
            | size ->
                let open Expr in
@@ -62,18 +62,18 @@ let arbitrary_ast =
     in
     fun Mtt.Location.{ data = expr; _ } ->
       match expr with
-      | Expr.Unit | Expr.VarL _ | Expr.VarG _ -> empty
+      | Expr.Unit | Expr.VarR _ | Expr.VarM _ -> empty
       | Expr.Fst pe -> shrink_unary Expr.fst pe
       | Expr.Snd pe -> shrink_unary Expr.snd pe
       | Expr.Pair (e1, e2) -> shrink_binary Expr.pair e1 e2
-      | Expr.Fun (idl, t_of_id, body) ->
-          shrink_unary (Expr.func idl t_of_id) body
+      | Expr.Fun (idr, t_of_id, body) ->
+          shrink_unary (Expr.func idr t_of_id) body
       | Expr.App (fe, arge) -> shrink_binary Expr.app fe arge
       | Expr.Box e -> shrink_unary Expr.box e
-      | Expr.Let (idl, bound_e, body) ->
-          shrink_binary (Expr.letc idl) bound_e body
-      | Expr.Letbox (idg, boxed_e, body) ->
-          shrink_binary (Expr.letbox idg) boxed_e body
+      | Expr.Let (idr, bound_e, body) ->
+          shrink_binary (Expr.letc idr) bound_e body
+      | Expr.Letbox (idm, boxed_e, body) ->
+          shrink_binary (Expr.letbox idm) boxed_e body
   in
   QCheck.make generator ~print:print_ast ~shrink:shrink_ast
 


### PR DESCRIPTION
These are the remnants of the previous naming policy