### PR TITLE
fix: browser support after introducing primitive numbers

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -39,4 +39,5 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   sexplib
   stdio
   zarith
+  zarith_stubs_js
   ))

--- a/mtt.opam
+++ b/mtt.opam
@@ -31,6 +31,7 @@ depends: [
   "sexplib"
   "stdio"
   "zarith"
+  "zarith_stubs_js"
   "odoc" {with-doc}
 ]
 build: [

--- a/src/MttError.ml
+++ b/src/MttError.ml
@@ -1,0 +1,16 @@
+(* open Base *)
+
+let located_to_string Location.{ data = error; loc } =
+  match error with
+  | `TypeMismatchError msg -> Location.pp ~msg loc
+  | `EvaluationError msg -> Location.pp ~msg loc
+  | `EnvUnboundRegularVarError (_, msg) -> Location.pp ~msg loc
+  | `EnvUnboundModalVarError (_, msg) -> Location.pp ~msg loc
+  | `UnboundRegularVarInsideBoxError (_, msg) -> Location.pp ~msg loc
+
+let to_string error =
+  match error with
+  | `EvaluationError msg -> msg
+  | `EnvUnboundRegularVarError (_, msg) -> msg
+  | `EnvUnboundModalVarError (_, msg) -> msg
+  | `TypeMismatchError msg -> msg

--- a/src/Util.ml
+++ b/src/Util.ml
@@ -1,0 +1,33 @@
+open Base
+open Result.Let_syntax
+open ParserInterface
+
+(* Parsing with error handling utilities *)
+let parse_from_e : type a. a ast_kind -> input_kind -> (a, error) Result.t =
+ fun ast_kind source ->
+  parse_from ast_kind source
+  |> Result.map_error ~f:(fun parse_error ->
+         [%string "Parse error: $parse_error"])
+
+(* Parsing and typechecking with error handling utilities *)
+let parse_and_typecheck source typ_str =
+  let%bind ast = parse_from_e Term source in
+  let%bind typ = parse_from_e Type (String typ_str) in
+  Typechecker.check ast typ
+  |> Result.map_error ~f:(fun infer_err ->
+         [%string "Typechecking error: $(MttError.located_to_string infer_err)"])
+
+(* Parsing and type inference with error handling utilities *)
+let parse_and_typeinfer source =
+  let%bind ast = parse_from_e Term source in
+  Typechecker.infer ast
+  |> Result.map_error ~f:(fun infer_err ->
+         [%string
+           "Type inference error: $(MttError.located_to_string infer_err)"])
+
+(* Parsing and evaluation with error handling utilities *)
+let parse_and_eval source =
+  let%bind ast = parse_from_e Term source in
+  Evaluator.eval ast
+  |> Result.map_error ~f:(fun eval_err ->
+         [%string "Evaluation error: $(MttError.to_string eval_err)"])

--- a/src/dune
+++ b/src/dune
@@ -20,7 +20,7 @@
  (modes byte native)
  (public_name mtt)
  (wrapped true)
- (libraries base stdio sexplib sedlex menhirLib pprint zarith)
+ (libraries base stdio sexplib sedlex menhirLib pprint zarith zarith_stubs_js)
  (preprocess
   (pps ppx_let ppx_compare ppx_sexp_conv ppx_string_interpolation sedlex.ppx))
  (synopsis "Modal Type Theory Library"))

--- a/web/mttweb.ml
+++ b/web/mttweb.ml
@@ -4,19 +4,6 @@ open Mtt
 open ParserInterface
 open Result.Let_syntax
 
-let format_located_error Location.{ data = error; loc } =
-  match error with
-  | `TypeMismatchError msg -> Location.pp ~msg loc
-  | `EvaluationError msg -> Location.pp ~msg loc
-  | `EnvUnboundVariableError (_, msg) -> Location.pp ~msg loc
-  | `UnboundRegularVarInsideBoxError (_, msg) -> Location.pp ~msg loc
-
-let format_error error =
-  match error with
-  | `EvaluationError msg -> msg
-  | `EnvUnboundVariableError (_, msg) -> msg
-  | `TypeMismatchError msg -> msg
-
 let parse_from_e : type a. a ast_kind -> input_kind -> (a, error) Result.t =
  fun ast_kind source ->
   parse_from ast_kind source
@@ -27,14 +14,15 @@ let parse_and_typeinfer source =
   let%bind ast = parse_from_e Term source in
   Typechecker.infer ast
   |> Result.map_error ~f:(fun infer_err ->
-         [%string "Type inference error: $(format_located_error infer_err)"])
+         [%string
+           "Type inference error: $(MttError.located_to_string infer_err)"])
 
 let parse_and_eval source =
   let open Result.Let_syntax in
   let%bind ast = parse_from_e Term source in
   Evaluator.eval ast
   |> Result.map_error ~f:(fun eval_err ->
-         [%string "Evaluation error: $(format_error eval_err)"])
+         [%string "Evaluation error: $(MttError.to_string eval_err)"])
 
 (* end copy-paste from ../bin/mtt.ml *)
 


### PR DESCRIPTION
The [zarith_stubs_js](https://github.com/janestreet/zarith_stubs_js) library needs to be added as a dependency.
Also, this commit removes some duplication between mttweb and mtt.

Fixes #64.