### PR TITLE
ci: add OCaml 4.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-version:
+          - 4.12.0
           - 4.11.1
           - 4.10.1
           - 4.09.1
@@ -42,7 +43,7 @@ jobs:
 
       - run: opam pin add mtt.dev . --no-action
 
-      - run: opam depext mtt --yes --with-doc --with-test
+      - run: opam depext mtt --yes
 
       - run: opam install . --deps-only --with-doc --with-test
 

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.15.0
+version=0.16.0

--- a/bin/mtt.ml
+++ b/bin/mtt.ml
@@ -20,7 +20,7 @@ let parse_expr source_file source_arg =
           PPrint.ToChannel.pretty 1.0 80 stdout document;
           Out_channel.newline stdout;
           `Ok ()
-      | Error err_msg -> `Error (false, err_msg) )
+      | Error err_msg -> `Error (false, err_msg))
 
 let check_expr source_file source_arg typ verbose =
   match osource source_file source_arg with
@@ -30,9 +30,9 @@ let check_expr source_file source_arg typ verbose =
       | Ok () ->
           if verbose then (
             Out_channel.output_string stdout "OK. Expression typechecks.";
-            Out_channel.newline stdout );
+            Out_channel.newline stdout);
           `Ok ()
-      | Error err_msg -> `Error (false, err_msg) )
+      | Error err_msg -> `Error (false, err_msg))
 
 let infer_type source_file source_arg =
   match osource source_file source_arg with
@@ -45,7 +45,7 @@ let infer_type source_file source_arg =
           PPrint.ToChannel.pretty 1.0 80 stdout document;
           Out_channel.newline stdout;
           `Ok ()
-      | Error err_msg -> `Error (false, err_msg) )
+      | Error err_msg -> `Error (false, err_msg))
 
 let eval_expr source_file source_arg =
   match osource source_file source_arg with
@@ -57,7 +57,7 @@ let eval_expr source_file source_arg =
           PPrint.ToChannel.pretty 1.0 80 stdout document;
           Out_channel.newline stdout;
           `Ok ()
-      | Error err_msg -> `Error (false, err_msg) )
+      | Error err_msg -> `Error (false, err_msg))
 
 (* Command line interface *)
 

--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   js_of_ocaml-ppx
   (menhir (>= 20201201))
   (ocaml (>= 4.07.0))
-  (ocamlformat (and :with-test (= 0.15.0)))
+  (ocamlformat (= 0.16.0))
   pprint
   ppx_compare
   ppx_let

--- a/mtt.opam
+++ b/mtt.opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml-ppx"
   "menhir" {>= "20201201"}
   "ocaml" {>= "4.07.0"}
-  "ocamlformat" {with-test & = "0.15.0"}
+  "ocamlformat" {with-test & = "0.16.0"}
   "pprint"
   "ppx_compare"
   "ppx_let"

--- a/src/Evaluator.ml
+++ b/src/Evaluator.ml
@@ -54,8 +54,8 @@ let rec subst_m term identm Location.{ data = body; _ } =
       letc idr (subst_m term identm bound) (subst_m term identm body)
   | Letbox { idm; boxed; body } ->
       Location.locate
-        ( if [%equal: Id.M.t] identm idm then
-          Letbox { idm; boxed = subst_m term identm boxed; body }
+        (if [%equal: Id.M.t] identm idm then
+         Letbox { idm; boxed = subst_m term identm boxed; body }
         else
           match refresh_m idm (free_vars_m term) with
           | Some new_i ->
@@ -75,7 +75,7 @@ let rec subst_m term identm Location.{ data = body; _ } =
                   idm;
                   boxed = subst_m term identm boxed;
                   body = subst_m term identm body;
-                } )
+                })
   | Match { matched; zbranch; pred; sbranch } ->
       match_with
         (subst_m term identm matched)
@@ -94,12 +94,12 @@ let rec eval_open gamma Location.{ data = expr; _ } =
       let%bind pv = eval_open gamma e in
       match pv with
       | Val.Pair { v1; v2 = _ } -> return v1
-      | _ -> Result.fail @@ `EvaluationError "fst is stuck" )
+      | _ -> Result.fail @@ `EvaluationError "fst is stuck")
   | Snd { e } -> (
       let%bind pv = eval_open gamma e in
       match pv with
       | Val.Pair { v1 = _; v2 } -> return v2
-      | _ -> Result.fail @@ `EvaluationError "snd is stuck" )
+      | _ -> Result.fail @@ `EvaluationError "snd is stuck")
   | Nat { n } -> return @@ Val.Nat { n }
   | BinOp { op; e1; e2 } -> (
       let%bind lhs = eval_open gamma e1 in
@@ -113,10 +113,10 @@ let rec eval_open gamma Location.{ data = expr; _ } =
           | Div ->
               if Nat.equal n2 Nat.zero then
                 Result.fail @@ `EvaluationError "Division by zero"
-              else return @@ Val.Nat { n = Nat.div n1 n2 } )
+              else return @@ Val.Nat { n = Nat.div n1 n2 })
       | _, _ ->
           Result.fail
-          @@ `EvaluationError "Only numbers can be used in arithmetics" )
+          @@ `EvaluationError "Only numbers can be used in arithmetics")
   | VarR { idr } -> Env.R.lookup gamma idr
   | VarM _ ->
       Result.fail
@@ -132,7 +132,7 @@ let rec eval_open gamma Location.{ data = expr; _ } =
           eval_open (Env.R.extend env idr argv) body
       | _ ->
           Result.fail
-          @@ `EvaluationError "Trying to apply an argument to a non-function" )
+          @@ `EvaluationError "Trying to apply an argument to a non-function")
   | Box { e } -> return @@ Val.Box { e }
   | Let { idr; bound; body } ->
       let%bind bound_v = eval_open gamma bound in
@@ -153,6 +153,6 @@ let rec eval_open gamma Location.{ data = expr; _ } =
           else eval_open (Env.R.extend gamma pred predn) sbranch
       | _ ->
           Result.fail
-          @@ `EvaluationError "Pattern matching is supported for Nat now" )
+          @@ `EvaluationError "Pattern matching is supported for Nat now")
 
 let eval expr = eval_open Env.R.emp expr

--- a/src/PrettyPrinter.ml
+++ b/src/PrettyPrinter.ml
@@ -93,28 +93,28 @@ module Doc : DOC = struct
       | VarR { idr } -> (
           match Env.R.lookup renv idr with
           | Ok v -> parens (of_val v)
-          | Error _ -> !^(Id.R.to_string idr) )
+          | Error _ -> !^(Id.R.to_string idr))
       | VarM { idm } -> !^(Id.M.to_string idm)
       | Fun { idr; ty_id; body } ->
           (parens_if (p > 1))
-            ( fun_kwd
+            (fun_kwd
             ^^ !^(Id.R.to_string idr)
-            ^^^ colon ^^^ of_type ty_id ^^ dot ^^ space ^^ walk 1 body )
+            ^^^ colon ^^^ of_type ty_id ^^ dot ^^ space ^^ walk 1 body)
       | App { fe; arge } ->
           group ((parens_if (p >= 2)) (walk 2 fe ^/^ walk 2 arge))
       | Box { e } -> group ((parens_if (p >= 2)) (box_kwd ^^ space ^^ walk 2 e))
       | Let { idr; bound; body } ->
           (parens_if (p > 1))
             (group
-               ( let_kwd
+               (let_kwd
                ^^^ !^(Id.R.to_string idr)
-               ^^^ equals ^^^ walk 2 bound ^^^ in_kwd ^/^ walk 1 body ))
+               ^^^ equals ^^^ walk 2 bound ^^^ in_kwd ^/^ walk 1 body))
       | Letbox { idm; boxed; body } ->
           (parens_if (p > 1))
             (group
-               ( letbox_kwd
+               (letbox_kwd
                ^^^ !^(Id.M.to_string idm)
-               ^^^ equals ^^^ walk 2 boxed ^^^ in_kwd ^/^ walk 1 body ))
+               ^^^ equals ^^^ walk 2 boxed ^^^ in_kwd ^/^ walk 1 body))
       | Match { matched; zbranch; pred; sbranch } ->
           let indentz = String.length (String.concat [ "| zero "; "=> " ]) in
           let indents =
@@ -122,14 +122,14 @@ module Doc : DOC = struct
               (String.concat [ "| succ "; Id.R.to_string pred; " => " ])
           in
           (parens_if (p > 1))
-            ( match_kwd ^^^ walk 1 matched ^^^ with_kwd ^/^ bar ^^^ zero_kwd
-            ^^^ darrow
+            (match_kwd ^^^ walk 1 matched ^^^ with_kwd ^/^ bar ^^^ zero_kwd
+           ^^^ darrow
             ^^^ nest indentz (walk 1 zbranch)
             ^/^ bar ^^^ succ_kwd
             ^^^ !^(Id.R.to_string pred)
             ^^^ darrow
             ^^^ nest indents (walk 1 sbranch)
-            ^/^ end_kwd )
+            ^/^ end_kwd)
     in
     walk 0 expr
 

--- a/src/Typechecker.ml
+++ b/src/Typechecker.ml
@@ -48,7 +48,7 @@ let rec check_open delta gamma Location.{ data = expr; loc } typ =
           let exp_ty = PrettyPrinter.Str.of_type typ in
           fail_in loc
           @@ `TypeMismatchError
-               [%string "Expected $exp_ty, but found product type"] )
+               [%string "Expected $exp_ty, but found product type"])
   | Fst { e } -> (
       let%bind ty = infer_open delta gamma e in
       match ty with
@@ -58,7 +58,7 @@ let rec check_open delta gamma Location.{ data = expr; loc } typ =
                "fst error: inferred type is different from the input one"
       | _ ->
           fail_in loc
-          @@ `TypeMismatchError "fst is applied to a non-product type" )
+          @@ `TypeMismatchError "fst is applied to a non-product type")
   | Snd { e } -> (
       let%bind ty = infer_open delta gamma e in
       match ty with
@@ -68,7 +68,7 @@ let rec check_open delta gamma Location.{ data = expr; loc } typ =
                "snd error: inferred type is different from the input one"
       | _ ->
           fail_in loc
-          @@ `TypeMismatchError "snd is applied to a non-product type" )
+          @@ `TypeMismatchError "snd is applied to a non-product type")
   | Nat _ ->
       let exp_ty = PrettyPrinter.Str.of_type typ in
       with_error_location loc
@@ -96,7 +96,7 @@ let rec check_open delta gamma Location.{ data = expr; loc } typ =
                   parameter"
           in
           check_open delta (Env.R.extend gamma idr dom) body cod
-      | _ -> fail_in loc @@ `TypeMismatchError "Arrow type expected" )
+      | _ -> fail_in loc @@ `TypeMismatchError "Arrow type expected")
   | App { fe; arge } -> (
       let%bind ty = infer_open delta gamma fe in
       match ty with
@@ -114,8 +114,8 @@ let rec check_open delta gamma Location.{ data = expr; loc } typ =
           | Error { data = `EnvUnboundRegularVarError (var, _); loc = var_loc }
             when Result.is_ok (Env.R.lookup gamma var) ->
               mk_unbound_regular_var_inside_box_error loc var_loc var
-          | x -> x )
-      | _ -> fail_in loc @@ `TypeMismatchError "Error: unboxed type" )
+          | x -> x)
+      | _ -> fail_in loc @@ `TypeMismatchError "Error: unboxed type")
   | Let { idr; bound; body } ->
       let%bind ty = infer_open delta gamma bound in
       check_open delta (Env.R.extend gamma idr ty) body typ
@@ -123,7 +123,7 @@ let rec check_open delta gamma Location.{ data = expr; loc } typ =
       let%bind ty = infer_open delta gamma boxed in
       match ty with
       | Type.Box { ty } -> check_open (Env.M.extend delta idm ty) gamma body typ
-      | _ -> fail_in loc @@ `TypeMismatchError "Inferred type is not a box" )
+      | _ -> fail_in loc @@ `TypeMismatchError "Inferred type is not a box")
   | Match { matched; zbranch; pred; sbranch } ->
       let%bind _ = check_open delta gamma matched Type.Nat in
       let%bind ty_empty = infer_open delta gamma zbranch in
@@ -142,14 +142,14 @@ and infer_open delta gamma Location.{ data = expr; loc } =
       | Type.Prod { ty1; ty2 = _ } -> return ty1
       | _ ->
           fail_in loc
-          @@ `TypeMismatchError "fst is applied to a non-product type" )
+          @@ `TypeMismatchError "fst is applied to a non-product type")
   | Snd { e } -> (
       let%bind ty = infer_open delta gamma e in
       match ty with
       | Type.Prod { ty1 = _; ty2 } -> return ty2
       | _ ->
           fail_in loc
-          @@ `TypeMismatchError "snd is applied to a non-product type" )
+          @@ `TypeMismatchError "snd is applied to a non-product type")
   | Nat _ -> return Type.Nat
   | BinOp { op = _; e1; e2 } ->
       let%map () = check_open delta gamma e1 Type.Nat
@@ -185,7 +185,7 @@ and infer_open delta gamma Location.{ data = expr; loc } =
       let%bind tyb = infer_open delta gamma boxed in
       match tyb with
       | Type.Box { ty } -> infer_open (Env.M.extend delta idm ty) gamma body
-      | _ -> fail_in loc @@ `TypeMismatchError "Inferred type is not a box" )
+      | _ -> fail_in loc @@ `TypeMismatchError "Inferred type is not a box")
   | Match { matched; zbranch; pred; sbranch } ->
       let%bind _ = check_open delta gamma matched Type.Nat in
       let%bind ty_zero = infer_open delta gamma zbranch in


### PR DESCRIPTION
ocamlformat had to be changed to 0.16 to support OCaml 4.07 - 4.12 (this is why some OCaml sources had to be reformatted)