### PR TITLE
Update PPrint and fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,13 @@ jobs:
           - macos-latest
           - ubuntu-latest
         ocaml-version:
-          - 4.12.0
+          - 4.14.0
+          - 4.13.1
+          - 4.12.1
           - 4.11.1
           - 4.10.1
           - 4.09.1
           - 4.08.1
-          - 4.07.1
 
     runs-on: ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _build/
 _opam/
 _esy/
 esy.lock/
+/mtt-lang.code-workspace

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.16.0
+version=0.21.0

--- a/HACKING.md
+++ b/HACKING.md
@@ -17,7 +17,7 @@ dependencies. By default, local switch will be available *only* inside this
 project.
 
 ```shell
-opam switch create ./ --deps-only --with-test ocaml-base-compiler.4.07.1
+opam switch create ./ --deps-only --with-test ocaml-base-compiler.4.08.1
 ```
 
 Note that this will create `_opam` directory at the project root with all the

--- a/bin/mtt.ml
+++ b/bin/mtt.ml
@@ -111,8 +111,9 @@ let help_cmd =
       `Blocks help_secs;
     ]
   in
-  ( Term.(ret (const help $ Arg.man_format $ Term.choice_names $ topic)),
-    Term.info "help" ~doc ~exits:Term.default_exits ~man )
+  let info = Cmd.info "help" ~doc ~exits:Cmd.Exit.defaults ~man in
+  Cmd.v info
+    Term.(ret (const help $ Arg.man_format $ Term.choice_names $ topic))
 
 let parse_cmd =
   let source_file =
@@ -129,7 +130,7 @@ let parse_cmd =
       & info [ "e"; "expression" ] ~docv:"EXPRESSION" ~doc)
   in
   let doc = "parse and pretty-print an expression" in
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let man =
     [
       `S Manpage.s_description;
@@ -139,8 +140,9 @@ let parse_cmd =
       `Blocks help_secs;
     ]
   in
-  ( Term.(ret (const parse_expr $ source_file $ source_arg)),
-    Term.info "parse" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
+  let info = Cmd.info "parse" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
+  Cmd.v info 
+    Term.(ret (const parse_expr $ source_file $ source_arg))
 
 let check_cmd =
   let type_arg =
@@ -163,7 +165,7 @@ let check_cmd =
     Arg.(value & flag & info [ "verbose" ] ~doc)
   in
   let doc = "typecheck an expression" in
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let man =
     [
       `S Manpage.s_description;
@@ -173,9 +175,9 @@ let check_cmd =
       `Blocks help_secs;
     ]
   in
-  ( Term.(
-      ret (const check_expr $ source_file $ source_arg $ type_arg $ verbose_arg)),
-    Term.info "check" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
+  let info = Cmd.info "check" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
+  Cmd.v info
+    Term.(ret (const check_expr $ source_file $ source_arg $ type_arg $ verbose_arg))
 
 let infer_cmd =
   let source_file =
@@ -190,7 +192,7 @@ let infer_cmd =
       & info [ "e"; "expression" ] ~docv:"EXPRESSION" ~doc)
   in
   let doc = "infer the type of an expression" in
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let man =
     [
       `S Manpage.s_description;
@@ -200,8 +202,9 @@ let infer_cmd =
       `Blocks help_secs;
     ]
   in
-  ( Term.(ret (const infer_type $ source_file $ source_arg)),
-    Term.info "infer" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
+  let info = Cmd.info "infer" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
+  Cmd.v info
+    Term.(ret (const infer_type $ source_file $ source_arg))
 
 let eval_cmd =
   let source_file =
@@ -216,7 +219,7 @@ let eval_cmd =
       & info [ "e"; "expression" ] ~docv:"EXPRESSION" ~doc)
   in
   let doc = "evaluate an expression" in
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let man =
     [
       `S Manpage.s_description;
@@ -226,17 +229,19 @@ let eval_cmd =
       `Blocks help_secs;
     ]
   in
-  ( Term.(ret (const eval_expr $ source_file $ source_arg)),
-    Term.info "eval" ~doc ~sdocs:Manpage.s_common_options ~exits ~man )
+  let info = Cmd.info "eval" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
+  Cmd.v info
+    Term.(ret (const eval_expr $ source_file $ source_arg))
+
+let cmds = [ parse_cmd; check_cmd; infer_cmd; eval_cmd; help_cmd ]
 
 let default_cmd =
   let doc = "a modal type theory implementation" in
   let sdocs = Manpage.s_common_options in
-  let exits = Term.default_exits in
+  let exits = Cmd.Exit.defaults in
   let man = help_secs in
-  ( Term.(ret (const (`Help (`Pager, None)))),
-    Term.info "mtt" ~version:"v0.0.0" ~doc ~sdocs ~exits ~man )
+  let info = Cmd.info "mtt" ~version:"v0.0.0" ~doc ~sdocs ~exits ~man in
+  let default = Term.(ret (const (`Help (`Pager, None))))
+  in Cmd.group info ~default cmds
 
-let cmds = [ parse_cmd; check_cmd; infer_cmd; eval_cmd; help_cmd ]
-
-let () = Term.(exit @@ eval_choice default_cmd cmds)
+let () = Caml.exit (Cmd.eval default_cmd)

--- a/bin/mtt.ml
+++ b/bin/mtt.ml
@@ -140,9 +140,10 @@ let parse_cmd =
       `Blocks help_secs;
     ]
   in
-  let info = Cmd.info "parse" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
-  Cmd.v info 
-    Term.(ret (const parse_expr $ source_file $ source_arg))
+  let info =
+    Cmd.info "parse" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  in
+  Cmd.v info Term.(ret (const parse_expr $ source_file $ source_arg))
 
 let check_cmd =
   let type_arg =
@@ -175,9 +176,12 @@ let check_cmd =
       `Blocks help_secs;
     ]
   in
-  let info = Cmd.info "check" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
+  let info =
+    Cmd.info "check" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  in
   Cmd.v info
-    Term.(ret (const check_expr $ source_file $ source_arg $ type_arg $ verbose_arg))
+    Term.(
+      ret (const check_expr $ source_file $ source_arg $ type_arg $ verbose_arg))
 
 let infer_cmd =
   let source_file =
@@ -202,9 +206,10 @@ let infer_cmd =
       `Blocks help_secs;
     ]
   in
-  let info = Cmd.info "infer" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
-  Cmd.v info
-    Term.(ret (const infer_type $ source_file $ source_arg))
+  let info =
+    Cmd.info "infer" ~doc ~sdocs:Manpage.s_common_options ~exits ~man
+  in
+  Cmd.v info Term.(ret (const infer_type $ source_file $ source_arg))
 
 let eval_cmd =
   let source_file =
@@ -230,8 +235,7 @@ let eval_cmd =
     ]
   in
   let info = Cmd.info "eval" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
-  Cmd.v info
-    Term.(ret (const eval_expr $ source_file $ source_arg))
+  Cmd.v info Term.(ret (const eval_expr $ source_file $ source_arg))
 
 let cmds = [ parse_cmd; check_cmd; infer_cmd; eval_cmd; help_cmd ]
 
@@ -241,7 +245,7 @@ let default_cmd =
   let exits = Cmd.Exit.defaults in
   let man = help_secs in
   let info = Cmd.info "mtt" ~version:"v0.0.0" ~doc ~sdocs ~exits ~man in
-  let default = Term.(ret (const (`Help (`Pager, None))))
-  in Cmd.group info ~default cmds
+  let default = Term.(ret (const (`Help (`Pager, None)))) in
+  Cmd.group info ~default cmds
 
 let () = Caml.exit (Cmd.eval default_cmd)

--- a/core/Ast.ml
+++ b/core/Ast.ml
@@ -52,29 +52,17 @@ module Expr = struct
 
   (* Wrappers for constructors *)
   let unit = Location.locate Unit
-
   let nat n = Location.locate @@ Nat { n }
-
   let pair e1 e2 = Location.locate @@ Pair { e1; e2 }
-
   let fst e = Location.locate @@ Fst { e }
-
   let snd e = Location.locate @@ Snd { e }
-
   let binop op e1 e2 = Location.locate @@ BinOp { op; e1; e2 }
-
   let var_r idr = Location.locate @@ VarR { idr }
-
   let var_m idm = Location.locate @@ VarM { idm }
-
   let func idr ty_id body = Location.locate @@ Fun { idr; ty_id; body }
-
   let app fe arge = Location.locate @@ App { fe; arge }
-
   let box e = Location.locate @@ Box { e }
-
   let letc idr bound body = Location.locate @@ Let { idr; bound; body }
-
   let letbox idm boxed body = Location.locate @@ Letbox { idm; boxed; body }
 
   let match_with matched zbranch pred sbranch =

--- a/core/Env.ml
+++ b/core/Env.ml
@@ -8,10 +8,12 @@ type error =
 module Make (Key : sig
   type t [@@deriving_inline sexp]
 
-  
-include
-  sig [@@@ocaml.warning "-32"] include Sexplib0.Sexpable.S with type  t :=  t
-  end[@@ocaml.doc "@inline"]
+  include sig
+    [@@@ocaml.warning "-32"]
+
+    include Ppx_sexp_conv_lib.Sexpable.S with type t := t
+  end
+  [@@ocaml.doc "@inline"]
 
   [@@@end]
 

--- a/core/Env.ml
+++ b/core/Env.ml
@@ -20,7 +20,6 @@ module Make (Key : sig
   include Equal.S with type t := t
 
   val context_kind : string
-
   val to_string : t -> string
 end) (Error : sig
   val makeError : Key.t * string -> [> error ]

--- a/core/Env.ml
+++ b/core/Env.ml
@@ -8,12 +8,10 @@ type error =
 module Make (Key : sig
   type t [@@deriving_inline sexp]
 
-  include sig
-    [@@@ocaml.warning "-32"]
-
-    include Ppx_sexp_conv_lib.Sexpable.S with type t := t
-  end
-  [@@ocaml.doc "@inline"]
+  
+include
+  sig [@@@ocaml.warning "-32"] include Sexplib0.Sexpable.S with type  t :=  t
+  end[@@ocaml.doc "@inline"]
 
   [@@@end]
 

--- a/core/Id.ml
+++ b/core/Id.ml
@@ -5,9 +5,7 @@ module type ID = sig
   (** Interface for identifiers *)
 
   val mk : string -> t
-
   val to_string : t -> string
-
   val context_kind : string
 
   include Comparable.S with type t := t
@@ -19,9 +17,7 @@ module R : ID = struct
     type t = string [@@deriving equal, compare, sexp]
 
     let mk = Fn.id
-
     let to_string = Fn.id
-
     let context_kind = "regular"
   end
 
@@ -35,9 +31,7 @@ module M : ID = struct
     type t = string [@@deriving equal, compare, sexp]
 
     let mk = Fn.id
-
     let to_string = Fn.id
-
     let context_kind = "modal"
   end
 

--- a/core/Lexer.ml
+++ b/core/Lexer.ml
@@ -7,29 +7,17 @@ open Parser
 exception LexError of Lexing.position * string
 
 let blank = [%sedlex.regexp? ' ' | '\t']
-
 let newline = [%sedlex.regexp? '\r' | '\n' | "\r\n"]
-
 let any_blank = [%sedlex.regexp? blank | newline]
-
 let digit = [%sedlex.regexp? '0' .. '9']
-
 let unsigned_integer = [%sedlex.regexp? digit, Star digit]
-
 let lower_case_letter = [%sedlex.regexp? 'a' .. 'z']
-
 let upper_case_letter = [%sedlex.regexp? 'A' .. 'Z']
-
 let letter = [%sedlex.regexp? lower_case_letter | upper_case_letter]
-
 let alphanum = [%sedlex.regexp? lower_case_letter | digit | '_']
-
 let regular_ident = [%sedlex.regexp? lower_case_letter, Star alphanum]
-
 let modal_ident = [%sedlex.regexp? lower_case_letter, Star alphanum, '\'']
-
 let type_ident = [%sedlex.regexp? upper_case_letter, Star alphanum | '_']
-
 let rec nom buf = match%sedlex buf with Plus any_blank -> nom buf | _ -> ()
 
 let token buf =

--- a/core/Location.ml
+++ b/core/Location.ml
@@ -30,7 +30,6 @@ let locate_start_end data s_pos e_pos =
   { data; loc }
 
 let locate ?(loc = NoSource) data = { data; loc }
-
 let empty pos = match pos with NoSource -> true | Source _ -> false
 
 let pp_column_range pos =

--- a/core/Location.mli
+++ b/core/Location.mli
@@ -1,15 +1,10 @@
 open Base
 
 type t
-
 type 'a located = { data : 'a; loc : t } [@@deriving equal, sexp]
 
 val locate_start_end : 'a -> Lexing.position -> Lexing.position -> 'a located
-
 val locate : ?loc:t -> 'a -> 'a located
-
 val empty : t -> bool
-
 val pp : ?msg:string -> t -> string
-
 val pp_column_range : t -> string

--- a/core/Nat.ml
+++ b/core/Nat.ml
@@ -3,27 +3,15 @@ open Base
 type t = Z.t
 
 let zero = Z.zero
-
 let one = Z.one
-
 let equal = Z.equal
-
 let of_string = Z.of_string
-
 let to_string = Z.to_string
-
 let t_of_sexp se = Z.of_string (Sexp.to_string se)
-
 let sexp_of_t z = Sexp.Atom (Z.to_string z)
-
 let of_int = Z.of_int
-
 let add = Z.add
-
 let sub n m = if Z.geq m n then zero else Z.sub n m
-
 let mul = Z.mul
-
 let div = Z.div
-
 let pred n = if equal n zero then zero else sub n one

--- a/core/Nat.mli
+++ b/core/Nat.mli
@@ -5,17 +5,10 @@ type t [@@deriving equal, sexp]
 include Stringable.S with type t := t
 
 val zero : t
-
 val one : t
-
 val of_int : int -> t
-
 val add : t -> t -> t
-
 val sub : t -> t -> t
-
 val mul : t -> t -> t
-
 val div : t -> t -> t
-
 val pred : t -> t

--- a/core/ParserInterface.ml
+++ b/core/ParserInterface.ml
@@ -5,11 +5,8 @@ module MG = MenhirLib.General
 open Ast
 
 type error = string
-
 type filename = string
-
 type _ ast_kind = Type : Type.t ast_kind | Term : Expr.t ast_kind
-
 type input_kind = Stdin | String of string | File of filename
 
 let parser_driver : type a. a ast_kind -> Lexing.position -> a MI.checkpoint =

--- a/core/ParserInterface.mli
+++ b/core/ParserInterface.mli
@@ -2,17 +2,11 @@ open Base
 open Ast
 
 type error = string
-
 type filename = string
-
 type _ ast_kind = Type : Type.t ast_kind | Term : Expr.t ast_kind
-
 type input_kind = Stdin | String of string | File of filename
 
 val parse_from : 'a ast_kind -> input_kind -> ('a, error) Result.t
-
 val parse_from_stdin : 'a ast_kind -> ('a, error) Result.t
-
 val parse_from_string : 'a ast_kind -> string -> ('a, error) Result.t
-
 val parse_from_file : 'a ast_kind -> filename -> ('a, error) Result.t

--- a/core/PrettyPrinter.ml
+++ b/core/PrettyPrinter.ml
@@ -4,9 +4,7 @@ open Ast
 
 module type DOC = sig
   val of_type : Type.t -> PPrint.document
-
   val of_expr : Expr.t -> PPrint.document
-
   val of_val : Val.t -> PPrint.document
 end
 
@@ -16,44 +14,26 @@ module Doc : DOC = struct
   let ( ^^^ ) left right = left ^^ space ^^ right
 
   let cross = !^"×"
-
   let unit_type = !^"()"
-
   let unit_term = !^"()"
-
   let arrow = !^"→"
-
   let darrow = !^"=>"
-
   let box_type = !^"□"
-
   let nat_type = !^"ℕ"
 
   (* keywords *)
   let fst_kwd = !^"π₁"
-
   let snd_kwd = !^"π₂"
-
   let box_kwd = !^"box"
-
   let fun_kwd = !^"λ"
-
   let let_kwd = !^"let"
-
   let letbox_kwd = !^"letbox"
-
   let in_kwd = !^"in"
-
   let match_kwd = !^"match"
-
   let with_kwd = !^"with"
-
   let end_kwd = !^"end"
-
   let zero_kwd = !^"zero" (* A temporary token for pattern matching on Nat *)
-
   let succ_kwd = !^"succ" (* A temporary token for pattern matching on Nat *)
-
   let parens_if b = if b then parens else fun x -> x
 
   let of_type =
@@ -151,9 +131,7 @@ end
 
 module type STR = sig
   val of_type : Type.t -> string
-
   val of_expr : Expr.t -> string
-
   val of_val : Val.t -> string
 end
 
@@ -166,8 +144,6 @@ module Str : STR = struct
     Buffer.contents buffer
 
   let of_type t = doc2str @@ Doc.of_type t
-
   let of_expr e = doc2str @@ Doc.of_expr e
-
   let of_val v = doc2str @@ Doc.of_val v
 end

--- a/core/PrettyPrinter.ml
+++ b/core/PrettyPrinter.ml
@@ -1,6 +1,5 @@
 open Base
 open PPrint
-open PPrintCombinators
 open Ast
 
 module type DOC = sig

--- a/core/PrettyPrinter.mli
+++ b/core/PrettyPrinter.mli
@@ -17,9 +17,7 @@ module Doc : DOC
 (** Convert ASTs to string  *)
 module type STR = sig
   val of_type : Type.t -> string
-
   val of_expr : Expr.t -> string
-
   val of_val : Val.t -> string
 end
 

--- a/core/Typechecker.ml
+++ b/core/Typechecker.ml
@@ -200,5 +200,4 @@ and infer_open delta gamma Location.{ data = expr; loc } =
       return ty_zero
 
 let check expr typ = check_open Env.M.emp Env.R.emp expr typ
-
 let infer expr = infer_open Env.M.emp Env.R.emp expr

--- a/core/dune
+++ b/core/dune
@@ -8,8 +8,11 @@
 
 (rule
  (targets ParserErrors.ml)
- (deps ParserErrors.messages UpdParserErrors.messages
-   NewParserErrors.messages Parser.mly)
+ (deps
+  ParserErrors.messages
+  UpdParserErrors.messages
+  NewParserErrors.messages
+  Parser.mly)
  (action
   (with-stdout-to
    ParserErrors.ml
@@ -20,7 +23,15 @@
  (modes byte native)
  (public_name mtt)
  (wrapped true)
- (libraries base stdio sexplib sedlex menhirLib pprint zarith zarith_stubs_js)
+ (libraries
+  base
+  stdio
+  sexplib
+  sedlex
+  menhirLib
+  pprint
+  zarith
+  zarith_stubs_js)
  (preprocess
   (pps ppx_let ppx_compare ppx_sexp_conv ppx_string_interpolation sedlex.ppx))
  (synopsis "Modal Type Theory Library"))
@@ -41,8 +52,13 @@
  (action
   (with-stdout-to
    UpdParserErrors.messages
-   (run %{bin:menhir} --merge-errors ParserErrors.messages --merge-errors
-     NewParserErrors.messages Parser.mly))))
+   (run
+    %{bin:menhir}
+    --merge-errors
+    ParserErrors.messages
+    --merge-errors
+    NewParserErrors.messages
+    Parser.mly))))
 
 (rule
  (alias runtest)

--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   js_of_ocaml-ppx
   (menhir (>= 20201201))
   (ocaml (>= 4.08.1))
-  (ocamlformat (and :with-test (= 0.16.0)))
+  (ocamlformat (and :with-test (= 0.21.0)))
   (pprint (>= 20220103))
   ppx_compare
   ppx_let

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   js_of_ocaml-tyxml
   js_of_ocaml-ppx
   (menhir (>= 20201201))
-  (ocaml (>= 4.07.0))
+  (ocaml (>= 4.11.0))
   (ocamlformat (and :with-test (= 0.16.0)))
   (pprint (>= 20220103))
   ppx_compare

--- a/dune-project
+++ b/dune-project
@@ -29,7 +29,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   (menhir (>= 20201201))
   (ocaml (>= 4.07.0))
   (ocamlformat (= 0.16.0))
-  pprint
+  (pprint (>= 20220103))
   ppx_compare
   ppx_let
   ppx_sexp_conv

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   js_of_ocaml-tyxml
   js_of_ocaml-ppx
   (menhir (>= 20201201))
-  (ocaml (>= 4.11.0))
+  (ocaml (>= 4.08.1))
   (ocamlformat (and :with-test (= 0.16.0)))
   (pprint (>= 20220103))
   ppx_compare

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.7)
+(lang dune 3.1)
 (cram enable)
 (using menhir 2.0)
 (name mtt)

--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   js_of_ocaml-ppx
   (menhir (>= 20201201))
   (ocaml (>= 4.07.0))
-  (ocamlformat (= 0.16.0))
+  (ocamlformat (and :with-test (= 0.16.0)))
   (pprint (>= 20220103))
   ppx_compare
   ppx_let

--- a/mtt.opam
+++ b/mtt.opam
@@ -19,8 +19,8 @@ depends: [
   "js_of_ocaml-tyxml"
   "js_of_ocaml-ppx"
   "menhir" {>= "20201201"}
-  "ocaml" {>= "4.11.0"}
-  "ocamlformat" {with-test & = "0.16.0"}
+  "ocaml" {>= "4.08.1"}
+  "ocamlformat" {with-test & = "0.21.0"}
   "pprint" {>= "20220103"}
   "ppx_compare"
   "ppx_let"

--- a/mtt.opam
+++ b/mtt.opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml-ppx"
   "menhir" {>= "20201201"}
   "ocaml" {>= "4.07.0"}
-  "ocamlformat" {= "0.16.0"}
+  "ocamlformat" {with-test & = "0.16.0"}
   "pprint" {>= "20220103"}
   "ppx_compare"
   "ppx_let"

--- a/mtt.opam
+++ b/mtt.opam
@@ -20,8 +20,8 @@ depends: [
   "js_of_ocaml-ppx"
   "menhir" {>= "20201201"}
   "ocaml" {>= "4.07.0"}
-  "ocamlformat" {with-test & = "0.16.0"}
-  "pprint"
+  "ocamlformat" {= "0.16.0"}
+  "pprint" {>= "20220103"}
   "ppx_compare"
   "ppx_let"
   "ppx_sexp_conv"

--- a/mtt.opam
+++ b/mtt.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/anton-trunov/mtt/issues"
 depends: [
   "base" {>= "v0.12.2" & < "v0.15.0"}
   "cmdliner"
-  "dune" {>= "2.7" & >= "2.0"}
+  "dune" {>= "3.1" & >= "2.0"}
   "js_of_ocaml"
   "js_of_ocaml-compiler"
   "js_of_ocaml-lwt"

--- a/mtt.opam
+++ b/mtt.opam
@@ -19,7 +19,7 @@ depends: [
   "js_of_ocaml-tyxml"
   "js_of_ocaml-ppx"
   "menhir" {>= "20201201"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.11.0"}
   "ocamlformat" {with-test & = "0.16.0"}
   "pprint" {>= "20220103"}
   "ppx_compare"

--- a/test/bin.t/run.t
+++ b/test/bin.t/run.t
@@ -34,26 +34,26 @@
 
 ## Missing file
   $ mtt parse MISSING_FILE.mtt
-  mtt: FILE argument: no `MISSING_FILE.mtt' file
-  Usage: mtt parse [OPTION]... [FILE]
-  Try `mtt parse --help' or `mtt --help' for more information.
+  mtt: FILE argument: no 'MISSING_FILE.mtt' file
+  Usage: mtt parse [--expression=EXPRESSION] [OPTION]… [FILE]
+  Try 'mtt parse --help' or 'mtt --help' for more information.
   [124]
 
   $ mtt check '()' MISSING_FILE.mtt
-  mtt: FILE argument: no `MISSING_FILE.mtt' file
-  Usage: mtt check [OPTION]... TYPE [FILE]
-  Try `mtt check --help' or `mtt --help' for more information.
+  mtt: FILE argument: no 'MISSING_FILE.mtt' file
+  Usage: mtt check [--expression=EXPRESSION] [--verbose] [OPTION]… TYPE [FILE]
+  Try 'mtt check --help' or 'mtt --help' for more information.
   [124]
 
   $ mtt infer MISSING_FILE.mtt
-  mtt: FILE argument: no `MISSING_FILE.mtt' file
-  Usage: mtt infer [OPTION]... [FILE]
-  Try `mtt infer --help' or `mtt --help' for more information.
+  mtt: FILE argument: no 'MISSING_FILE.mtt' file
+  Usage: mtt infer [--expression=EXPRESSION] [OPTION]… [FILE]
+  Try 'mtt infer --help' or 'mtt --help' for more information.
   [124]
 
   $ mtt eval MISSING_FILE.mtt
-  mtt: FILE argument: no `MISSING_FILE.mtt' file
-  Usage: mtt eval [OPTION]... [FILE]
-  Try `mtt eval --help' or `mtt --help' for more information.
+  mtt: FILE argument: no 'MISSING_FILE.mtt' file
+  Usage: mtt eval [--expression=EXPRESSION] [OPTION]… [FILE]
+  Try 'mtt eval --help' or 'mtt --help' for more information.
   [124]
 

--- a/test/evaluator/modal-counterexamples.t
+++ b/test/evaluator/modal-counterexamples.t
@@ -7,4 +7,4 @@ bad accesses the free modal variable y'
   > x'
   > EOF
   mtt: Evaluation error: Modal variable access is not possible in a well-typed term
-  [1]
+  [124]

--- a/test/parser/parser-errors.t
+++ b/test/parser/parser-errors.t
@@ -3,7 +3,7 @@
 ## Misc.
   $ mtt parse -e ""
   mtt: Parse error: An expression is expected. This may result from a missing or unexpected lexeme or an attempt to parse a type-level expression
-  [1]
+  [124]
 
 ## Keyword-related errors
 
@@ -11,19 +11,19 @@
 (All of the following error messages can be changed)
   $ mtt parse -e "box box"
   mtt: Parse error: Boxed expression is expected
-  [1]
+  [124]
   $ mtt parse -e "f box"
   mtt: Parse error: Sometimes this happens when you say "let box" instead of "letbox" or try to apply a function to "box"
-  [1]
+  [124]
   $ mtt parse -e "fst box"
   mtt: Parse error: An expression after fst is expected. This primitive can be only used fully applied.
-  [1]
+  [124]
   $ mtt parse -e "snd box"
   mtt: Parse error: An expression after snd is expected. This primitive can be only used fully applied.
-  [1]
+  [124]
   $ mtt parse -e "fun box : A. box"
   mtt: Parse error: A regular identifier expected. This happens, when e.g. a modal identifier is used fun x' : T. ...
-  [1]
+  [124]
 
 
 ## Types
@@ -31,42 +31,42 @@
 ### Missing type annotations
   $ mtt parse -e "fun x => x"
   mtt: Parse error: Function parameter is missing type annotation
-  [1]
+  [124]
 
 ### Type idents must be capitalized
   $ mtt parse -e "fun x : a. x"
   mtt: Parse error: Valid type expected. Make sure uninterpreted type identifiers are capitalized and there are no unbalanced parentheses
-  [1]
+  [124]
 
 ### This is unfortunately unrecognized (putting here to document it)
   $ mtt parse -e "fun (x : a). x"
   mtt: Parse error: Unrecognized syntax error. Please report your example
-  [1]
+  [124]
 
 ### Missing open parenthesis
   $ mtt parse -e "fun x : A -> B). x"
   mtt: Parse error: Separator between bound variable and lambda body is missing. Use e.g. => or . Also, make sure parentheses are balanced
-  [1]
+  [124]
 
 ### Missing closing parenthesis
   $ mtt parse -e "fun x : (A -> B. x"
   mtt: Parse error: Missing closing parenthesis at type level. Or unexpected lexeme, like => is used instead of ->. Or you are using (A, B) instead of A * B
-  [1]
+  [124]
 
 ### The wrong arrow as a separator between the lambda parameter and its body
   $ mtt parse -e "fun x : A -> x"
   mtt: Parse error: Valid codomain type is expected. Sometimes this happens if -> is used instead of =>
-  [1]
+  [124]
 
 ### Missing box's argument
   $ mtt parse -e "fun x : []. x"
   mtt: Parse error: Type-level box must be followed by a type
-  [1]
+  [124]
 
 ### Use a star or a cross in product types, not a comma
   $ mtt parse -e "fun x : (A, B). x"
   mtt: Parse error: Missing closing parenthesis at type level. Or unexpected lexeme, like => is used instead of ->. Or you are using (A, B) instead of A * B
-  [1]
+  [124]
 
 ## STLC terms
 
@@ -78,7 +78,7 @@ mtt: Parse error: Binary application must be parenthesized like so: (f x) y
 ### Parens instead of angle brackets for pairs
   $ mtt parse -e "fun x : A. (x, x)"
   mtt: Parse error: Missing closing parenthesis or missing obligatory parentheses for multi-arg function application: (f x) y or maybe using parentheses instead of angle brackets for pairs
-  [1]
+  [124]
 
 
 ## Modal terms
@@ -86,7 +86,7 @@ mtt: Parse error: Binary application must be parenthesized like so: (f x) y
 ### Modal identifier in the wrong context
   $ mtt parse -e "fun x' : A. x"
   mtt: Parse error: A regular identifier expected. This happens, when e.g. a modal identifier is used fun x' : T. ...
-  [1]
+  [124]
 
 ### box needs to be applied to an expression
 $ mtt parse -e "box 42"
@@ -96,46 +96,46 @@ mtt: Parse error: Boxed expression is expected
 ### letbox is one single keyword, not two
   $ mtt parse -e "let box x' = box () in x'"
   mtt: Parse error: Sometimes this happens when you say "let box" instead of "letbox" or try to apply a function to "box"
-  [1]
+  [124]
 
 ### letbox needs its bound var to end with apostrophy
   $ mtt parse -e "letbox x = box () in x"
   mtt: Parse error: A modal identifier is expected. It should start with a lowercase letter and end with an apostrophe (').
-  [1]
+  [124]
 
 ## Regular "let .. in" expression
 
 ### Bound variable in "let" expression must be term, not type
   $ mtt parse -e "let x = []"
   mtt: Parse error: Variable in "let" expression must be term, not type
-  [1]
+  [124]
 
 ### After "in" must term must follow, not type
   $ mtt parse -e "let x = () in []"
   mtt: Parse error: Expected term after "in"-keyword, not type
-  [1]
+  [124]
 
 ### Extra closed parenthesis
   $ mtt parse -e "let x = ())"
   mtt: Parse error: Missing or unexpected lexeme in parenthesized expression
-  [1]
+  [124]
 
 ### Missing "in" keyword
   $ mtt parse -e "let x = fun y: A. y"
   mtt: Parse error: Missing or unexpected lexeme in parenthesized expression
-  [1]
+  [124]
 
   $ mtt parse -e "let x = () x"
   mtt: Parse error: Missing or unexpected lexeme in parenthesized expression
-  [1]
+  [124]
 
   $ mtt parse -e "let x = () y = x"
   mtt: Parse error: Missing or unexpected lexeme in parenthesized expression
-  [1]
+  [124]
 
   $ mtt parse -e "let x = (fun z: A. z) y = () in x y"
   mtt: Parse error: Missing or unexpected lexeme in parenthesized expression
-  [1]
+  [124]
 
 ### Match-expression
   $ mtt parse <<EOF
@@ -143,7 +143,7 @@ mtt: Parse error: Boxed expression is expected
   > end
   > EOF
   mtt: Parse error: Empty branch in match-expression
-  [1]
+  [124]
 
   $ mtt parse <<EOF
   > match x with
@@ -151,7 +151,7 @@ mtt: Parse error: Boxed expression is expected
   > end
   > EOF
   mtt: Parse error: Empty branch in match-expression
-  [1]
+  [124]
 
   $ mtt parse <<EOF
   > match x
@@ -159,14 +159,14 @@ mtt: Parse error: Boxed expression is expected
   > end
   > EOF
   mtt: Parse error: Missing "with" keyword
-  [1]
+  [124]
 
   $ mtt parse <<EOF
   > match x with
   > | zero => ()
   > EOF
   mtt: Parse error: Empty branch in match-expression
-  [1]
+  [124]
 
   $ mtt parse <<EOF
   > match x with
@@ -174,7 +174,7 @@ mtt: Parse error: Boxed expression is expected
   > | succ n => ()
   > EOF
   mtt: Parse error: END token wasn't found in the end of the match-expression
-  [1]
+  [124]
 
   $ mtt parse <<EOF
   > match x with
@@ -183,8 +183,8 @@ mtt: Parse error: Boxed expression is expected
   > end
   > EOF
   mtt: Parse error: Incorrect match-expression
-  [1]
+  [124]
 
   $ mtt parse -e "() + zero"
   mtt: Parse error: ZERO token can be used in match-expression only
-  [1]
+  [124]

--- a/test/typechecker/modal-counterexamples.t
+++ b/test/typechecker/modal-counterexamples.t
@@ -2,7 +2,7 @@ Prawitz's example of failure of the substitution principle
   $ mtt infer -e "λf:B -> []A. λy:B. (λx:[]A. box x) (f y)"
   mtt: Type inference error: regular variable "x" is accessed in box expression (28:33) at 32:33
        file name :  Not a file, lines :  0 - 0, column :  32 - 33
-  [1]
+  [124]
 
 Error reports about an unknown regular variable in boxed expression in different cases:
 
@@ -10,16 +10,16 @@ find a variable from the context behind a box
   $ mtt infer -e "λx:A. box (λy:B. box (λz:[]A. y))"
   mtt: Type inference error: regular variable "y" is accessed in box expression (17:32) at 30:31
        file name :  Not a file, lines :  0 - 0, column :  30 - 31
-  [1]
+  [124]
 
 find a variable from the context behind another box
   $ mtt infer -e "λx:A. box (λy:B. box (λz:[]A. x))"
   mtt: Type inference error: regular variable "x" is accessed in box expression (6:33) at 30:31
        file name :  Not a file, lines :  0 - 0, column :  30 - 31
-  [1]
+  [124]
 
 find a variable that isn't contained in any regular context above in the AST
   $ mtt infer -e "λx:A. box (λy:B. box (λz:[]A. w))"
   mtt: Type inference error: "w" is not found in the regular environment!
        file name :  Not a file, lines :  0 - 0, column :  30 - 31
-  [1]
+  [124]

--- a/test/typechecker/stlc-counterexamples.t
+++ b/test/typechecker/stlc-counterexamples.t
@@ -2,35 +2,35 @@ Example of incorrect operation with a tuple
   $ mtt infer -e "λx:A. λy:B. fst x"
   mtt: Type inference error: fst is applied to a non-product type
        file name :  Not a file, lines :  0 - 0, column :  12 - 17
-  [1]
+  [124]
 
   $ mtt infer -e "λx:A. λy:B. snd x"
   mtt: Type inference error: snd is applied to a non-product type
        file name :  Not a file, lines :  0 - 0, column :  12 - 17
-  [1]
+  [124]
 
 Example of 
   $ mtt infer -e "λf:A -> B. λy:B . λz:B . (fst <f,y>) z"
   mtt: Type inference error: Unexpected regular variable type
        file name :  Not a file, lines :  0 - 0, column :  37 - 38
-  [1]
+  [124]
 
 Pattern matching for Nat
   $ mtt infer -e "1 + ()"
   mtt: Type inference error: Expected ℕ, but found Unit type
        file name :  Not a file, lines :  0 - 0, column :  4 - 6
-  [1]
+  [124]
 
 
   $ mtt infer -e "1 + <1,1>"
   mtt: Type inference error: Expected ℕ, but found product type
        file name :  Not a file, lines :  0 - 0, column :  4 - 9
-  [1]
+  [124]
 
   $ mtt infer -e "<1, 1> + 1"
   mtt: Type inference error: Expected ℕ, but found product type
        file name :  Not a file, lines :  0 - 0, column :  0 - 6
-  [1]
+  [124]
 
   $ mtt infer <<EOF
   > let f = fun n: Nat.
@@ -42,7 +42,7 @@ Pattern matching for Nat
   > EOF
   mtt: Type inference error: All branches of pattern matching must have the same type
        file name :  Not a file, lines :  2 - 5, column :  2 - 5
-  [1]
+  [124]
 
   $ mtt infer <<EOF
   > let f = fun n: Nat.
@@ -54,4 +54,4 @@ Pattern matching for Nat
   > EOF
   mtt: Type inference error: All branches of pattern matching must have the same type
        file name :  Not a file, lines :  2 - 5, column :  2 - 5
-  [1]
+  [124]

--- a/test/typechecker/stlc.t
+++ b/test/typechecker/stlc.t
@@ -92,7 +92,7 @@ tests for location
   > EOF
   mtt: Type inference error: Unexpected regular variable type
        file name :  Not a file, lines :  1 - 1, column :  42 - 43
-  [1]
+  [124]
 
   $ mtt infer <<EOF
   > let true = λx:A. λy:B . x in
@@ -101,7 +101,7 @@ tests for location
   > EOF
   mtt: Type inference error: Unexpected regular variable type
        file name :  Not a file, lines :  3 - 3, column :  42 - 43
-  [1]
+  [124]
 
 Evaluator for Nat
   $ mtt infer <<EOF

--- a/web/ace.ml
+++ b/web/ace.ml
@@ -21,7 +21,7 @@ type editor = { editor : editor ace_editor Js.t }
 let create_editor div =
   let editor =
     Js.Unsafe.new_obj
-      (Js.Unsafe.variable "ace.edit")
+      (Js.Unsafe.pure_js_expr "ace.edit")
       [| Js.Unsafe.inject (Js.string div) |]
   in
   let data = { editor } in

--- a/web/ace.ml
+++ b/web/ace.ml
@@ -4,15 +4,10 @@ module Html = Dom_html
 class type ['a] ace_editor =
   object
     method clearSelection : unit Js.meth
-
     method getValue : Js.js_string Js.t Js.meth
-
     method setMode : Js.js_string Js.t -> unit Js.meth
-
     method setOptions : Js.json Js.t -> unit Js.meth
-
     method setTheme : Js.js_string Js.t -> unit Js.meth
-
     method setValue : Js.js_string Js.t -> unit Js.meth
   end
 
@@ -28,7 +23,6 @@ let create_editor div =
   data
 
 let clear_selection { editor } = editor##clearSelection
-
 let get_value { editor } = Js.to_string editor##getValue
 
 let set_mode { editor } mode =
@@ -36,7 +30,6 @@ let set_mode { editor } mode =
   session ## (setMode (Js.string mode))
 
 let set_theme { editor } theme = editor ## (setTheme (Js.string theme))
-
 let set_value { editor } value = editor ## (setValue (Js.string value))
 
 let set_options { editor } options =

--- a/web/ace.mli
+++ b/web/ace.mli
@@ -4,15 +4,9 @@ module Html = Dom_html
 type editor
 
 val create_editor : string -> editor
-
 val clear_selection : editor -> unit
-
 val get_value : editor -> string
-
 val set_mode : editor -> string -> unit
-
 val set_options : editor -> string -> unit
-
 val set_theme : editor -> string -> unit
-
 val set_value : editor -> string -> unit


### PR DESCRIPTION
After dependencies update the build had been failing due to changes in the PPrint API. The build problems have been resolved, and the new version of PPrint has been fixed in `dune-project` file.