### PR TITLE
feat: add REPL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ that.
 ## How to use
 
 You can try out the typechecker and evaluator online: https://mtt-lang.github.io/mtt-web or
-install `mtt` locally using the [build instructions](./HACKING.md).
+install `mtt` locally using the [build instructions](./HACKING.md). After installing you
+can run `mtt` directly or use REPL (`dune exec -- repl`). See [following README](./repl/README.md) about REPL features.
 
 Here is how you can use a local `mtt` setup. Use `mtt --help` to list all
 the subcommands `mtt` supports. Each of those subcommands also supports `--help`

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ that.
 ## How to use
 
 You can try out the typechecker and evaluator online: https://mtt-lang.github.io/mtt-web or
-install `mtt` locally using the [build instructions](./HACKING.md). After installing you
-can run `mtt` directly or use REPL (`dune exec -- repl`). See [following README](./repl/README.md) about REPL features.
+install `mtt` locally using the [build instructions](./HACKING.md). After installing you can run `mtt` directly.
 
 Here is how you can use a local `mtt` setup. Use `mtt --help` to list all
 the subcommands `mtt` supports. Each of those subcommands also supports `--help`
@@ -90,6 +89,8 @@ flag. Here are some examples:
   (box (λx : (). x)))
   (box ((λx : (). x) ())))
   ```
+
+- Running REPL: `mtt repl`. See [following README](./repl/README.md) about REPL features.
 
 ## Language Syntax
 

--- a/bin/dune
+++ b/bin/dune
@@ -1,7 +1,7 @@
 (executable
  (name mtt)
  (flags :standard -safe-string)
- (libraries base cmdliner mtt pprint)
+ (libraries base cmdliner mtt pprint repl)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_string_interpolation)))
 

--- a/bin/mtt.ml
+++ b/bin/mtt.ml
@@ -237,7 +237,24 @@ let eval_cmd =
   let info = Cmd.info "eval" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
   Cmd.v info Term.(ret (const eval_expr $ source_file $ source_arg))
 
-let cmds = [ parse_cmd; check_cmd; infer_cmd; eval_cmd; help_cmd ]
+let repl_cmd =
+  let repl () =
+    Repl.run ();
+    `Ok ()
+  in
+  let doc = "run MTT REPL" in
+  let exits = Cmd.Exit.defaults in
+  let man =
+    [
+      `S Manpage.s_description;
+      `P "Runs an interactive shell of mtt language.";
+      `Blocks help_secs;
+    ]
+  in
+  let info = Cmd.info "repl" ~doc ~sdocs:Manpage.s_common_options ~exits ~man in
+  Cmd.v info Term.(ret (const repl $ const ()))
+
+let cmds = [ parse_cmd; check_cmd; infer_cmd; eval_cmd; repl_cmd; help_cmd ]
 
 let default_cmd =
   let doc = "a modal type theory implementation" in

--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,7 @@ Based on Modal Type Theory as given by F. Pfenning et al.")
   js_of_ocaml-lwt
   js_of_ocaml-tyxml
   js_of_ocaml-ppx
+  lambda-term
   (menhir (>= 20201201))
   (ocaml (>= 4.08.1))
   (ocamlformat (and :with-test (= 0.21.0)))

--- a/man/dune
+++ b/man/dune
@@ -25,10 +25,22 @@
 
 (rule
  (with-stdout-to
+  mtt-repl.1
+  (run %{bin:mtt} repl --help=groff)))
+
+(rule
+ (with-stdout-to
   mtt-help.1
   (run %{bin:mtt} help --help=groff)))
 
 (install
  (section man)
  (package mtt)
- (files mtt.1 mtt-parse.1 mtt-check.1 mtt-infer.1 mtt-eval.1 mtt-help.1))
+ (files
+  mtt.1
+  mtt-parse.1
+  mtt-check.1
+  mtt-infer.1
+  mtt-eval.1
+  mtt-repl.1
+  mtt-help.1))

--- a/mtt.opam
+++ b/mtt.opam
@@ -18,6 +18,7 @@ depends: [
   "js_of_ocaml-lwt"
   "js_of_ocaml-tyxml"
   "js_of_ocaml-ppx"
+  "lambda-term"
   "menhir" {>= "20201201"}
   "ocaml" {>= "4.08.1"}
   "ocamlformat" {with-test & = "0.21.0"}

--- a/repl/README.md
+++ b/repl/README.md
@@ -1,0 +1,15 @@
+# REPL
+
+Enter `dune exec -- repl` to start MTT REPL. To interact with the terminal the [lambda-term](https://github.com/ocaml-community/lambda-term) library is used.
+
+## Available commands:
+
+| Command          |            Meaning                 |
+| :--------------: | :--------------------------------: |
+| `<term>`         | evaluate/run `<term>`              |
+| `:eval <term>`   | evaluate/run `<term>`              |
+| `:infer <term>`  | infer the type of a `<term>`       |
+| `:print <term>`  | parse and pretty-print a `<term>`  |
+| `:help`          | print help message                 |
+| `:exit`          | exit REPL                          |
+

--- a/repl/README.md
+++ b/repl/README.md
@@ -1,6 +1,6 @@
 # REPL
 
-Enter `dune exec -- repl` to start MTT REPL. To interact with the terminal the [lambda-term](https://github.com/ocaml-community/lambda-term) library is used.
+Enter `mtt repl` to start MTT REPL. To interact with the terminal the [lambda-term](https://github.com/ocaml-community/lambda-term) library is used.
 
 ## Available commands:
 

--- a/repl/Repl.ml
+++ b/repl/Repl.ml
@@ -1,0 +1,180 @@
+open Mtt
+
+(* Util functions *)
+let doc2string document =
+  let buffer = Buffer.create 100 in
+  PPrint.ToBuffer.pretty 1.0 80 buffer document;
+  Buffer.contents buffer
+
+let eval_repl expr =
+  match Util.parse_and_eval expr with
+  | Ok res -> Ok (doc2string @@ PrettyPrinter.Doc.of_val res)
+  | Error err_msg -> Error err_msg
+
+let infer_repl expr =
+  match Util.parse_and_typeinfer expr with
+  | Ok res -> Ok (doc2string @@ PrettyPrinter.Doc.of_type res)
+  | Error err_msg -> Error err_msg
+
+let parse_repl expr =
+  match Util.parse_from_e Term expr with
+  | Ok res -> Ok (doc2string @@ PrettyPrinter.Doc.of_expr res)
+  | Error err_msg -> Error err_msg
+
+module MttRepl : sig
+  type state
+
+  (* initial state *)
+  val initial_state : state
+
+  (* final state *)
+  val exit_state : state
+
+  (* the greeting message *)
+  val greeting : string
+
+  (* repl prompt *)
+  val prompt : state -> string
+
+  (* runs command in current state and return pair [new state, result] or error *)
+  val eval : state -> string -> (state * string, string) Result.t
+end = struct
+  type state = { n : int }
+
+  type command =
+    | Eval of string
+    | Infer of string
+    | Print of string
+    | Help
+    | Logo
+    | Exit
+  [@@deriving equal, sexp]
+
+  let initial_state = { n = 1 }
+  let exit_state = { n = -1 }
+
+  let greeting =
+    "Welcome to MTT REPL!\n\
+     Enter an expression for evaluation or type `:help` for more information"
+
+  let prompt state = Printf.sprintf "[%d]> " state.n
+
+  let safe_string_index str c =
+    try Some (String.index str c) with Not_found -> None
+
+  let lsplit_by_space s =
+    match safe_string_index s ' ' with
+    | Some space_index ->
+        let l = Str.string_before s space_index in
+        let r = Str.string_after s (space_index + 1) in
+        (l, r)
+    | None -> (s, "")
+
+  let parse_instruction instr =
+    if String.get instr 0 != ':' then Ok (Eval instr)
+    else
+      let cmd, expr = lsplit_by_space instr in
+      match cmd with
+      | ":eval" -> Ok (Eval expr)
+      | ":infer" -> Ok (Infer expr)
+      | ":print" -> Ok (Print expr)
+      | ":help" -> Ok Help
+      | ":logo" -> Ok Logo
+      | ":exit" -> Ok Exit
+      | _ ->
+          Error
+            (Printf.sprintf "Unknown command `%s`." cmd
+            ^ "Please, use the `:help` command to see a list of available \
+               commands")
+
+  let help_message =
+    "A list of available command:\n\
+    \  <term>            evaluate/run <term>\n\
+    \  :eval <term>      evaluate/run <term>\n\
+    \  :infer <term>     infer the type of a <term>\n\
+    \  :print <term>     parse and pretty-print a <term>\n\
+    \  :help             print this message\n\
+    \  :exit             exit repl"
+
+  let mtt_logo =
+    "\n\
+    \ __  __ _____ _____   ____  _____ ____  _     \n\
+     |  \\/  |_   _|_   _| |  _ \\| ____|  _ \\| |    \n\
+     | |\\/| | | |   | |   | |_) |  _| | |_) | |    \n\
+     | |  | | | |   | |   |  _ <| |___|  __/| |___ \n\
+     |_|  |_| |_|   |_|   |_| \\_\\_____|_|   |_____|\n\
+     ==============================================\n\
+    \ "
+
+  let exit_message = "Leaving MTT REPL."
+
+  let run_command = function
+    | Eval expr -> eval_repl (String expr)
+    | Infer expr -> infer_repl (String expr)
+    | Print expr -> parse_repl (String expr)
+    | Help -> Ok help_message
+    | Logo -> Ok mtt_logo
+    | Exit -> Ok exit_message
+
+  let eval state instr =
+    let open Base.Result.Let_syntax in
+    let new_state = { n = state.n + 1 } in
+    let%bind cmd = parse_instruction instr in
+    Result.map
+      (fun res ->
+        if res == exit_message then (exit_state, res) else (new_state, res))
+      (run_command cmd)
+end
+
+open React
+open Lwt
+open LTerm_text
+open LTerm_style
+
+(* Customization of the read-line engine *)
+class read_line ~term ~history ~state =
+  object (self)
+    inherit LTerm_read_line.read_line ~history ()
+    inherit [Zed_string.t] LTerm_read_line.term term
+    method! show_box = false
+    initializer self#set_prompt (S.const (eval [ S (MttRepl.prompt state) ]))
+  end
+
+(* Main loop *)
+let rec loop term history state =
+  if state == MttRepl.exit_state then return ()
+  else
+    Lwt.catch
+      (fun () ->
+        let rl =
+          new read_line ~term ~history:(LTerm_history.contents history) ~state
+        in
+        rl#run >|= fun command -> Some command)
+      (function Sys.Break -> return None | exn -> Lwt.fail exn)
+    >>= function
+    | Some command ->
+        (let command_utf8 = Zed_string.to_utf8 command in
+         match MttRepl.eval state command_utf8 with
+         | Ok (new_state, res) ->
+             LTerm.fprintls term (eval [ S res ]) >>= fun () -> return new_state
+         | Error err_msg ->
+             LTerm.fprintls term (eval [ B_fg red; S err_msg; E_fg ])
+             >>= fun () -> return state)
+        >>= fun next_state ->
+        LTerm_history.add history command;
+        loop term history next_state
+    | None -> loop term history state
+
+(* Entry point *)
+let main () =
+  LTerm_inputrc.load () >>= fun () ->
+  Lwt.catch
+    (fun () ->
+      let state = MttRepl.initial_state in
+      Lazy.force LTerm.stdout >>= fun term ->
+      LTerm.printls (eval [ B_fg green; S MttRepl.greeting; E_fg ])
+      >>= fun () -> loop term (LTerm_history.create []) state)
+    (function
+      | LTerm_read_line.Interrupt -> Lwt.return () | exn -> Lwt.fail exn)
+
+let () = Lwt_main.run (main ())

--- a/repl/Repl.ml
+++ b/repl/Repl.ml
@@ -177,4 +177,4 @@ let main () =
     (function
       | LTerm_read_line.Interrupt -> Lwt.return () | exn -> Lwt.fail exn)
 
-let () = Lwt_main.run (main ())
+let run () = Lwt_main.run (main ())

--- a/repl/dune
+++ b/repl/dune
@@ -1,0 +1,7 @@
+(executable
+ (name repl)
+ (public_name repl)
+ (libraries base pprint lambda-term mtt str)
+ (preprocess
+  (pps ppx_let))
+ (flags :standard -safe-string))

--- a/repl/dune
+++ b/repl/dune
@@ -1,6 +1,5 @@
-(executable
+(library
  (name repl)
- (public_name repl)
  (libraries base pprint lambda-term mtt str)
  (preprocess
   (pps ppx_let))


### PR DESCRIPTION
I got some free time and wanted to do something useful for this project:) I haven’t written in OCaml for a long time, so the code can be ugly in places...

This PR contains a REPL (#18) implementation based on [lambda-term](https://github.com/ocaml-community/lambda-term) library. More information about REPL features can be found in [this README](https://github.com/mtt-lang/mtt-lang/blob/repl/repl/README.md).

### **Small demo:**
![mttrepl](https://user-images.githubusercontent.com/44073463/169709948-45798d1a-cf59-4015-b8dc-5d58298dba91.gif)

### **Some remarks:**

1. Same code duplication problem as `mttweb.ml` (function `eval_repl`, `infer_repl` and `parse_repl`). Maybe I'll try to fix it!
2. Probably, it makes sense adding support for global variable names, so as not to write one big term. With this feature, using REPL will be more convenient!