### PR TITLE
fix: rename `mtt` from core to `mtt_lib`

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,7 +1,7 @@
 (executable
  (name mtt)
  (flags :standard -safe-string)
- (libraries base cmdliner mtt pprint)
+ (libraries base cmdliner mtt_lib pprint)
  (preprocess
   (pps ppx_let ppx_sexp_conv ppx_string_interpolation)))
 

--- a/bin/mtt.ml
+++ b/bin/mtt.ml
@@ -1,6 +1,6 @@
 open Base
 open Stdio
-open Mtt
+open Mtt_lib
 open ParserInterface
 
 let osource source_file source_arg =

--- a/core/dune
+++ b/core/dune
@@ -19,7 +19,7 @@
    (run %{bin:menhir} --compile-errors ParserErrors.messages Parser.mly))))
 
 (library
- (name mtt)
+ (name mtt_lib)
  (modes byte native)
  (public_name mtt)
  (wrapped true)

--- a/test/pretty-printer/dune
+++ b/test/pretty-printer/dune
@@ -1,5 +1,5 @@
 (test
  (name ppTest)
- (libraries mtt qcheck)
+ (libraries mtt_lib qcheck)
  (preprocess
   (pps ppx_let ppx_compare ppx_sexp_conv)))

--- a/test/pretty-printer/ppTest.ml
+++ b/test/pretty-printer/ppTest.ml
@@ -1,7 +1,7 @@
 open Base
-open Mtt
-open Mtt.Ast
-module MttPP = Mtt.PrettyPrinter
+open Mtt_lib
+open Mtt_lib.Ast
+module MttPP = Mtt_lib.PrettyPrinter
 
 (* QCheck generator for the arbitrary (and most likely invalid) expressions *)
 let generator =
@@ -74,7 +74,7 @@ let arbitrary_ast =
       <+> (shrink_ast arg2 >|= fun arg2' -> cons arg1 arg2' arg3)
       <+> (shrink_ast arg3 >|= fun arg3' -> cons arg1 arg2 arg3')
     in
-    fun Mtt.Location.{ data = expr; _ } ->
+    fun Mtt_lib.Location.{ data = expr; _ } ->
       match expr with
       | Expr.Unit | Expr.VarR _ | Expr.VarM _ -> empty
       | Expr.Fst { e } -> shrink_unary Expr.fst e
@@ -108,7 +108,7 @@ let test =
       let ast_string = Stdlib.Buffer.contents buffer in
       let _ = Stdlib.Buffer.clear buffer in
       let parsed_ast =
-        match Mtt.ParserInterface.parse_from_string Term ast_string with
+        match Mtt_lib.ParserInterface.parse_from_string Term ast_string with
         | Ok ast -> ast
         | Error err_msg ->
             QCheck.Test.fail_reportf "Parse error: %s\nParser input: %s" err_msg

--- a/web/dune
+++ b/web/dune
@@ -3,6 +3,6 @@
  (modes js)
  (js_of_ocaml
   (flags +base/runtime.js --disable genprim --source-map))
- (libraries js_of_ocaml-lwt base mtt pprint js_of_ocaml-tyxml)
+ (libraries js_of_ocaml-lwt base mtt_lib pprint js_of_ocaml-tyxml)
  (preprocess
   (pps ppx_let js_of_ocaml-ppx ppx_sexp_conv ppx_string_interpolation)))

--- a/web/mttweb.ml
+++ b/web/mttweb.ml
@@ -1,5 +1,5 @@
 open Base
-open Mtt
+open Mtt_lib
 open ParserInterface
 
 let eval_web term =


### PR DESCRIPTION
Fixes #55.

I found out that the problem is in the conflict between `mtt`-executable from `bin/` and `mtt`-library from `core/`. They have the same name and for some reason it confuses OCaml LSP, but dune works fine at the same time... So I decided to rename `mtt`-library to `mtt_lib`. The `$ mtt` command is preserved.

If we accept these rename, then in the `repl`-branch we also need to rename `mtt` to `mtt_lib`.